### PR TITLE
fix: perform dirty check after async generation completes

### DIFF
--- a/.changeset/olive-jokes-drum.md
+++ b/.changeset/olive-jokes-drum.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Check the `dirty` state of the file an additional time to prevent writing to the file when the user types directly after saving

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,14 @@ import {
   isNoSubstitutionTemplateLiteral,
   isTaggedTemplateExpression,
 } from 'typescript';
+import fs from 'fs';
+
+export function isFileDirty(fileName: string, source: ts.SourceFile) {
+  const contents = fs.readFileSync(fileName, 'utf-8');
+  const currentText = source.getFullText();
+
+  return currentText !== contents;
+}
 
 export function findNode(
   sourceFile: ts.SourceFile,


### PR DESCRIPTION
Currently we have a slight race condition, in terms of writing to the TypeScript file. We check whether the user saved to kick off type-generation and when the async process for type-generation completes we write to the file, however our user could have performed additional changes in this small timeframe, this is why we have introduced an additional dirty check in the `.then` of our type-generation.

fixes https://github.com/0no-co/GraphQLSP/issues/25