### PR TITLE
feat: display documentation for fields and fragments

### DIFF
--- a/.changeset/grumpy-toes-serve.md
+++ b/.changeset/grumpy-toes-serve.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': minor
+---
+
+Display some documentation alongside fields and fragments, for fields it will show the documentation or the type and for fragmentSpreads the typeCondition will be displayed


### PR DESCRIPTION
Resolves https://github.com/0no-co/GraphQLSP/issues/20

This will use the TS.LabelDetails to show some information alongside the `fieldName` or `fragmentName`. For suggested `FragmentSpread` insertions we will display the `typeCondition` while for fields we will display the `documentation` found in the schema _or_ the associated field-type.