### PR TITLE
Add e2e test for renaming an operation name

### DIFF
--- a/test/e2e/fixture-project/fixtures/rename.ts
+++ b/test/e2e/fixture-project/fixtures/rename.ts
@@ -1,0 +1,9 @@
+import { gql } from '@urql/core';
+
+const PostsQuery = gql`
+  query Posts {
+    posts {
+      title
+    }
+  }
+`;

--- a/test/e2e/rename.test.ts
+++ b/test/e2e/rename.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import fs from 'node:fs';
 import url from 'node:url';
 import ts from 'typescript/lib/tsserverlibrary';
+import { waitForExpect } from './util';
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
@@ -48,17 +49,12 @@ describe('Operation name', () => {
       tmpfile: outFile,
     } satisfies ts.server.protocol.SavetoRequestArgs);
 
-    await server.waitForResponse(
-      response => response.type === 'event' && response.event === 'setTypings'
-    );
-    await server.waitForResponse(
-      response =>
-        response.type === 'event' && response.event === 'suggestionDiag'
-    );
+    await waitForExpect(() => {
+      expect(fs.readFileSync(outFile, 'utf-8')).toContain(
+        `as typeof import('./rename.generated').PostsDocument`
+      );
+    });
 
-    expect(fs.readFileSync(outFile, 'utf-8')).toContain(
-      `as typeof import('./rename.generated').PostsDocument`
-    );
     server.sendCommand('updateOpen', {
       openFiles: [
         {
@@ -75,16 +71,13 @@ describe('Operation name', () => {
       tmpfile: outFile,
     } satisfies ts.server.protocol.SavetoRequestArgs);
 
-    await server.waitForResponse(
-      response =>
-        response.type === 'event' && response.event === 'suggestionDiag'
-    );
-
-    expect(fs.readFileSync(outFile, 'utf-8')).toContain(
-      `as typeof import('./rename.generated').PostListDocument`
-    );
-    expect(fs.readFileSync(genFile, 'utf-8')).toContain(
-      'export const PostListDocument ='
-    );
+    await waitForExpect(() => {
+      expect(fs.readFileSync(outFile, 'utf-8')).toContain(
+        `as typeof import('./rename.generated').PostListDocument`
+      );
+      expect(fs.readFileSync(genFile, 'utf-8')).toContain(
+        'export const PostListDocument ='
+      );
+    });
   }, 12500);
 });

--- a/test/e2e/rename.test.ts
+++ b/test/e2e/rename.test.ts
@@ -1,0 +1,83 @@
+import { expect, afterAll, beforeAll, it, describe } from 'vitest';
+import { TSServer } from './server';
+import path from 'node:path';
+import fs from 'node:fs';
+import url from 'node:url';
+import ts from 'typescript/lib/tsserverlibrary';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+const projectPath = path.resolve(__dirname, 'fixture-project');
+describe('Operation name', () => {
+  const outFile = path.join(projectPath, 'rename.ts');
+  const genFile = path.join(projectPath, 'rename.generated.ts');
+
+  let server: TSServer;
+  beforeAll(async () => {
+    server = new TSServer(projectPath, { debugLog: false });
+  });
+
+  afterAll(() => {
+    try {
+      fs.unlinkSync(outFile);
+      fs.unlinkSync(genFile);
+    } catch {}
+  });
+
+  it('gets renamed correctly', async () => {
+    server.sendCommand('open', {
+      file: outFile,
+      fileContent: '// empty',
+      scriptKindName: 'TS',
+    } satisfies ts.server.protocol.OpenRequestArgs);
+
+    server.sendCommand('updateOpen', {
+      openFiles: [
+        {
+          file: outFile,
+          fileContent: fs.readFileSync(
+            path.join(projectPath, 'fixtures/rename.ts'),
+            'utf-8'
+          ),
+        },
+      ],
+    } satisfies ts.server.protocol.UpdateOpenRequestArgs);
+
+    server.sendCommand('saveto', {
+      file: outFile,
+      tmpfile: outFile,
+    } satisfies ts.server.protocol.SavetoRequestArgs);
+
+    await server.waitForResponse(
+      response => response.type === 'event' && response.event === 'setTypings'
+    );
+
+    server.sendCommand('updateOpen', {
+      openFiles: [
+        {
+          file: outFile,
+          fileContent: fs
+            .readFileSync(outFile, 'utf-8')
+            .replace('query Posts', 'query PostList'),
+        },
+      ],
+    } satisfies ts.server.protocol.UpdateOpenRequestArgs);
+
+    server.sendCommand('saveto', {
+      file: outFile,
+      tmpfile: outFile,
+    } satisfies ts.server.protocol.SavetoRequestArgs);
+
+    await server.waitForResponse(
+      response =>
+        response.type === 'event' && response.event === 'suggestionDiag'
+    );
+
+    expect(fs.readFileSync(outFile, 'utf-8')).toContain(
+      `as typeof import('./rename.generated').PostListDocument`
+    );
+    expect(fs.readFileSync(genFile, 'utf-8')).toContain(
+      'export const PostListDocument ='
+    );
+  }, 12500);
+});

--- a/test/e2e/rename.test.ts
+++ b/test/e2e/rename.test.ts
@@ -51,7 +51,14 @@ describe('Operation name', () => {
     await server.waitForResponse(
       response => response.type === 'event' && response.event === 'setTypings'
     );
+    await server.waitForResponse(
+      response =>
+        response.type === 'event' && response.event === 'suggestionDiag'
+    );
 
+    expect(fs.readFileSync(outFile, 'utf-8')).toContain(
+      `as typeof import('./rename.generated').PostsDocument`
+    );
     server.sendCommand('updateOpen', {
       openFiles: [
         {

--- a/test/e2e/util.ts
+++ b/test/e2e/util.ts
@@ -1,0 +1,33 @@
+import { vi } from 'vitest';
+
+type WaitForExpectOptions = {
+  timeout?: number;
+  interval?: number;
+};
+
+export const waitForExpect = async (
+  expectFn: () => void,
+  { interval = 200, timeout = 10000 }: WaitForExpectOptions = {}
+) => {
+  // @sinonjs/fake-timers injects `clock` property into setTimeout
+  const usesFakeTimers = 'clock' in setTimeout;
+
+  if (usesFakeTimers) vi.useRealTimers();
+
+  const start = Date.now();
+
+  while (true) {
+    try {
+      expectFn();
+      break;
+    } catch {}
+
+    if (Date.now() - start > timeout) {
+      throw new Error('Timeout');
+    }
+
+    await new Promise(resolve => setTimeout(resolve, interval));
+  }
+
+  if (usesFakeTimers) vi.useFakeTimers();
+};


### PR DESCRIPTION
Added e2e for renaming an operation name.
I added this as a new file so the tests can run in parallel.

// does this require a changeset?