### PR TITLE
Do not suggest fields/fragments/input vars that are already present.

### DIFF
--- a/.changeset/unlucky-geese-double.md
+++ b/.changeset/unlucky-geese-double.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': minor
+---
+
+Do not suggest fields/fragments/input vars that are already present.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/index.js",
   "module": "./dist/index.module.js",
   "scripts": {
-    "build": "rollup -c ./scripts/build.mjs",
+    "build": "pnpm --filter @0no-co/graphqlsp build",
     "prepare": "husky install",
     "dev": "pnpm --filter @0no-co/graphqlsp dev",
     "launch-debug": "./scripts/launch-debug.sh",

--- a/packages/graphqlsp/src/autoComplete.ts
+++ b/packages/graphqlsp/src/autoComplete.ts
@@ -8,7 +8,12 @@ import {
   getAutocompleteSuggestions,
   getTokenAtPosition,
   getTypeInfo,
+  RuleKinds,
+  State,
+  RuleKind,
+  CompletionItem,
 } from 'graphql-language-service';
+import { runOnlineParser } from 'graphql-language-service/dist/interface/getAutocompleteSuggestions';
 import { FragmentDefinitionNode, GraphQLSchema, Kind, parse } from 'graphql';
 
 import { bubbleUpTemplate, findNode, getSource } from './ast';
@@ -42,28 +47,13 @@ export function getGraphQLCompletions(
     if (!foundToken || !schema.current) return undefined;
 
     const text = resolveTemplate(node, filename, info);
-    let fragments: Array<FragmentDefinitionNode> = [];
-    try {
-      const parsed = parse(text, { noLocation: true });
-      fragments = parsed.definitions.filter(
-        x => x.kind === Kind.FRAGMENT_DEFINITION
-      ) as Array<FragmentDefinitionNode>;
-    } catch (e) {}
 
     const cursor = new Cursor(foundToken.line, foundToken.start);
-    const suggestions = getAutocompleteSuggestions(
+
+    const [suggestions, spreadSuggestions] = getSuggestionsInternal(
       schema.current,
       text,
       cursor
-    );
-
-    const token = getTokenAtPosition(text, cursor);
-    const spreadSuggestions = getSuggestionsForFragmentSpread(
-      token,
-      getTypeInfo(schema.current, token.state),
-      schema.current,
-      text,
-      fragments
     );
 
     return {
@@ -99,5 +89,139 @@ export function getGraphQLCompletions(
     };
   } else {
     return undefined;
+  }
+}
+
+export function getSuggestionsInternal(
+  schema: GraphQLSchema,
+  queryText: string,
+  cursor: Cursor
+): [CompletionItem[], CompletionItem[]] {
+  const token = getTokenAtPosition(queryText, cursor);
+
+  let fragments: Array<FragmentDefinitionNode> = [];
+  try {
+    const parsed = parse(queryText, { noLocation: true });
+    fragments = parsed.definitions.filter(
+      x => x.kind === Kind.FRAGMENT_DEFINITION
+    ) as Array<FragmentDefinitionNode>;
+  } catch (e) {}
+
+  let suggestions = getAutocompleteSuggestions(schema, queryText, cursor);
+  let spreadSuggestions = getSuggestionsForFragmentSpread(
+    token,
+    getTypeInfo(schema, token.state),
+    schema,
+    queryText,
+    fragments
+  );
+
+  const state =
+    token.state.kind === 'Invalid' ? token.state.prevState : token.state;
+  const parentName = getParentDefinition(token.state, RuleKinds.FIELD)?.name;
+
+  if (state && parentName) {
+    const { kind } = state;
+
+    // Argument names
+    if (kind === RuleKinds.ARGUMENTS || kind === RuleKinds.ARGUMENT) {
+      const usedArguments = new Set<String>();
+
+      runOnlineParser(queryText, (_, state) => {
+        if (state.kind === RuleKinds.ARGUMENT) {
+          const parentDefinition = getParentDefinition(state, RuleKinds.FIELD);
+          if (
+            parentName &&
+            state.name &&
+            parentDefinition?.name === parentName
+          ) {
+            usedArguments.add(state.name);
+          }
+        }
+      });
+
+      suggestions = suggestions.filter(
+        suggestion => !usedArguments.has(suggestion.label)
+      );
+    }
+
+    // Field names
+    if (
+      kind === RuleKinds.SELECTION_SET ||
+      kind === RuleKinds.FIELD ||
+      kind === RuleKinds.ALIASED_FIELD
+    ) {
+      const usedFields = new Set<string>();
+      const usedFragments = getUsedFragments(queryText, parentName);
+
+      runOnlineParser(queryText, (_, state) => {
+        if (
+          state.kind === RuleKinds.FIELD ||
+          state.kind === RuleKinds.ALIASED_FIELD
+        ) {
+          const parentDefinition = getParentDefinition(state, RuleKinds.FIELD);
+          if (
+            parentDefinition &&
+            parentDefinition.name === parentName &&
+            state.name
+          ) {
+            usedFields.add(state.name);
+          }
+        }
+      });
+
+      suggestions = suggestions.filter(
+        suggestion => !usedFields.has(suggestion.label)
+      );
+      spreadSuggestions = spreadSuggestions.filter(
+        suggestion => !usedFragments.has(suggestion.label)
+      );
+    }
+
+    // Fragment spread names
+    if (kind === RuleKinds.FRAGMENT_SPREAD) {
+      const usedFragments = getUsedFragments(queryText, parentName);
+      suggestions = suggestions.filter(
+        suggestion => !usedFragments.has(suggestion.label)
+      );
+      spreadSuggestions = spreadSuggestions.filter(
+        suggestion => !usedFragments.has(suggestion.label)
+      );
+    }
+  }
+
+  return [suggestions, spreadSuggestions];
+}
+
+function getUsedFragments(queryText: string, parentName: string | undefined) {
+  const usedFragments = new Set<string>();
+
+  runOnlineParser(queryText, (_, state) => {
+    if (state.kind === RuleKinds.FRAGMENT_SPREAD && state.name) {
+      const parentDefinition = getParentDefinition(state, RuleKinds.FIELD);
+      if (parentName && parentDefinition?.name === parentName) {
+        usedFragments.add(state.name);
+      }
+    }
+  });
+
+  return usedFragments;
+}
+
+/**
+ * This is vendoref from https://github.com/graphql/graphiql/blob/aeedf7614e422c783f5cfb5e226c5effa46318fd/packages/graphql-language-service/src/interface/getAutocompleteSuggestions.ts#L831
+ */
+function getParentDefinition(state: State, kind: RuleKind) {
+  if (state.prevState?.kind === kind) {
+    return state.prevState;
+  }
+  if (state.prevState?.prevState?.kind === kind) {
+    return state.prevState.prevState;
+  }
+  if (state.prevState?.prevState?.prevState?.kind === kind) {
+    return state.prevState.prevState.prevState;
+  }
+  if (state.prevState?.prevState?.prevState?.prevState?.kind === kind) {
+    return state.prevState.prevState.prevState.prevState;
   }
 }

--- a/packages/graphqlsp/src/autoComplete.ts
+++ b/packages/graphqlsp/src/autoComplete.ts
@@ -211,7 +211,7 @@ function getUsedFragments(queryText: string, parentName: string | undefined) {
 }
 
 /**
- * This is vendoref from https://github.com/graphql/graphiql/blob/aeedf7614e422c783f5cfb5e226c5effa46318fd/packages/graphql-language-service/src/interface/getAutocompleteSuggestions.ts#L831
+ * This is vendored from https://github.com/graphql/graphiql/blob/aeedf7614e422c783f5cfb5e226c5effa46318fd/packages/graphql-language-service/src/interface/getAutocompleteSuggestions.ts#L831
  */
 function getParentDefinition(state: State, kind: RuleKind) {
   if (state.prevState?.kind === kind) {

--- a/test/e2e/graphqlsp.test.ts
+++ b/test/e2e/graphqlsp.test.ts
@@ -93,12 +93,6 @@ describe('simple', () => {
       },
       {
         ...defaultAttrs,
-        name: 'title',
-        sortText: '1title',
-        labelDetails: { detail: ' String!' },
-      },
-      {
-        ...defaultAttrs,
         name: 'content',
         sortText: '2content',
         labelDetails: { detail: ' String!' },

--- a/test/e2e/server.ts
+++ b/test/e2e/server.ts
@@ -24,7 +24,7 @@ export class TSServer {
   ) {
     const tsserverPath = path.resolve(
       projectPath,
-      'node_modules/typescript/lib/tsserver.js'
+      '../../../node_modules/typescript/lib/tsserver.js'
     );
 
     fs.lstatSync(tsserverPath);


### PR DESCRIPTION
## Description

Resolves https://github.com/0no-co/GraphQLSP/issues/16

When autocomplete is triggered in the following scenarios:
* field names
* input vars names
* fragment spreads

The LSP will no longer recommend members which are already present 🎉 

Demo: https://www.loom.com/share/3d342956e5234f69ba962dfdd8ab2d15

**Note: I do have unit tests for this code, but getting some error about duplicate `graphql` versions running in the test, so trying to fix that.**

### Contributing this into `graphql-language-service`

I'll try contributing this change into the graphiql repo for the language service package, but as this change current behavior, it will probably take a while to get merged (in the case that it does get accepted 😅). In the case it does get merged, I'll remove some of the code added here as it won't longer be needed (some parts of it still will be to, as we add fragment spreads on our side to do the '...' completion before as well).