### PR TITLE
chore(workspace): publish with provenance

### DIFF
--- a/.changeset/five-monkeys-ring.md
+++ b/.changeset/five-monkeys-ring.md
@@ -1,0 +1,5 @@
+---
+"@0no-co/graphqlsp": patch
+---
+
+publish with provenance

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,9 @@ jobs:
     name: Release
     runs-on: ubuntu-20.04
     timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/packages/graphqlsp/package.json
+++ b/packages/graphqlsp/package.json
@@ -47,5 +47,8 @@
     "@graphql-codegen/typescript-operations": "^3.0.3",
     "graphql-language-service": "^5.1.3",
     "node-fetch": "^2.0.0"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }


### PR DESCRIPTION
This now uses [provenance](https://docs.npmjs.com/generating-provenance-statements) to prove that this was a good deploy.