### PR TITLE
avoid giving diagnostics for stuff falling out of the node-range

### DIFF
--- a/.changeset/hungry-hairs-draw.md
+++ b/.changeset/hungry-hairs-draw.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Avoid polluting with diagnostics not in current file

--- a/packages/graphqlsp/src/ast/resolve.ts
+++ b/packages/graphqlsp/src/ast/resolve.ts
@@ -9,63 +9,110 @@ import ts from 'typescript/lib/tsserverlibrary';
 import { findNode } from '.';
 import { getSource } from '../ast';
 
+type TemplateResult = {
+  combinedText: string;
+  resolvedSpans: Array<{
+    identifier: string;
+    original: { start: number; length: number };
+    new: { start: number; length: number };
+  }>;
+};
+
 export function resolveTemplate(
   node: TaggedTemplateExpression,
   filename: string,
   info: ts.server.PluginCreateInfo
-): string {
+): TemplateResult {
   let templateText = node.template.getText().slice(1, -1);
   if (
     isNoSubstitutionTemplateLiteral(node.template) ||
     node.template.templateSpans.length === 0
   ) {
-    return templateText;
+    return { combinedText: templateText, resolvedSpans: [] };
   }
 
-  node.template.templateSpans.forEach(span => {
-    if (isIdentifier(span.expression)) {
-      const definitions = info.languageService.getDefinitionAtPosition(
-        filename,
-        span.expression.getStart()
-      );
-      if (!definitions) return;
+  let addedCharacters = 0;
+  const resolvedSpans = node.template.templateSpans
+    .map(span => {
+      if (isIdentifier(span.expression)) {
+        const definitions = info.languageService.getDefinitionAtPosition(
+          filename,
+          span.expression.getStart()
+        );
+        if (!definitions) return;
 
-      const def = definitions[0];
-      const src = getSource(info, def.fileName);
-      if (!src) return;
+        const def = definitions[0];
+        const src = getSource(info, def.fileName);
+        if (!src) return;
 
-      const node = findNode(src, def.textSpan.start);
-      if (!node || !node.parent) return;
+        const node = findNode(src, def.textSpan.start);
+        if (!node || !node.parent) return;
 
-      const parent = node.parent;
-      if (ts.isVariableDeclaration(parent)) {
-        if (
-          parent.initializer &&
-          isTaggedTemplateExpression(parent.initializer)
-        ) {
-          const text = resolveTemplate(parent.initializer, def.fileName, info);
-          templateText = templateText.replace(
-            '${' + span.expression.escapedText + '}',
-            text
-          );
-        } else if (
-          parent.initializer &&
-          isAsExpression(parent.initializer) &&
-          isTaggedTemplateExpression(parent.initializer.expression)
-        ) {
-          const text = resolveTemplate(
-            parent.initializer.expression,
-            def.fileName,
-            info
-          );
-          templateText = templateText.replace(
-            '${' + span.expression.escapedText + '}',
-            text
-          );
+        const parent = node.parent;
+        if (ts.isVariableDeclaration(parent)) {
+          const identifierName = span.expression.escapedText;
+          const originalStart = span.expression.getStart();
+          const originalRange = {
+            start: originalStart,
+            length: span.expression.end - originalStart,
+          };
+          if (
+            parent.initializer &&
+            isTaggedTemplateExpression(parent.initializer)
+          ) {
+            const text = resolveTemplate(
+              parent.initializer,
+              def.fileName,
+              info
+            );
+            templateText = templateText.replace(
+              '${' + span.expression.escapedText + '}',
+              text.combinedText
+            );
+
+            const alteredSpan = {
+              identifier: identifierName,
+              original: originalRange,
+              new: {
+                start: originalRange.start + addedCharacters,
+                length: text.combinedText.length,
+              },
+            };
+            addedCharacters += text.combinedText.length - originalRange.length;
+            return alteredSpan;
+          } else if (
+            parent.initializer &&
+            isAsExpression(parent.initializer) &&
+            isTaggedTemplateExpression(parent.initializer.expression)
+          ) {
+            const text = resolveTemplate(
+              parent.initializer.expression,
+              def.fileName,
+              info
+            );
+            templateText = templateText.replace(
+              '${' + span.expression.escapedText + '}',
+              text.combinedText
+            );
+            const alteredSpan = {
+              identifier: identifierName,
+              original: originalRange,
+              new: {
+                start: originalRange.start + addedCharacters,
+                length: text.combinedText.length,
+              },
+            };
+            addedCharacters += text.combinedText.length - originalRange.length;
+            return alteredSpan;
+          }
+
+          return undefined;
         }
       }
-    }
-  });
 
-  return templateText;
+      return undefined;
+    })
+    .filter(Boolean) as TemplateResult['resolvedSpans'];
+
+  return { combinedText: templateText, resolvedSpans };
 }

--- a/packages/graphqlsp/src/ast/resolve.ts
+++ b/packages/graphqlsp/src/ast/resolve.ts
@@ -51,10 +51,12 @@ export function resolveTemplate(
         const parent = node.parent;
         if (ts.isVariableDeclaration(parent)) {
           const identifierName = span.expression.escapedText;
-          const originalStart = span.expression.getStart();
+          // we reduce by two to account for the "${"
+          const originalStart = span.expression.getStart() - 2;
           const originalRange = {
             start: originalStart,
-            length: span.expression.end - originalStart,
+            // we add 1 to account for the "}"
+            length: span.expression.end - originalStart + 1,
           };
           if (
             parent.initializer &&

--- a/packages/graphqlsp/src/ast/resolve.ts
+++ b/packages/graphqlsp/src/ast/resolve.ts
@@ -29,9 +29,11 @@ export function resolveTemplate(
         span.expression.getStart()
       );
       if (!definitions) return;
+
       const def = definitions[0];
       const src = getSource(info, def.fileName);
       if (!src) return;
+
       const node = findNode(src, def.textSpan.start);
       if (!node || !node.parent) return;
 

--- a/packages/graphqlsp/src/autoComplete.ts
+++ b/packages/graphqlsp/src/autoComplete.ts
@@ -48,7 +48,7 @@ export function getGraphQLCompletions(
     const foundToken = getToken(template, cursorPosition);
     if (!foundToken || !schema.current) return undefined;
 
-    const text = resolveTemplate(node, filename, info);
+    const text = resolveTemplate(node, filename, info).combinedText;
 
     const cursor = new Cursor(foundToken.line, foundToken.start);
 

--- a/packages/graphqlsp/src/diagnostics.ts
+++ b/packages/graphqlsp/src/diagnostics.ts
@@ -112,9 +112,7 @@ export function getGraphQLDiagnostics(
             return {
               ...x,
               start: locatedInFragment.original.start,
-              length:
-                locatedInFragment.original.start +
-                locatedInFragment.original.length,
+              length: locatedInFragment.original.length,
             };
           } else {
             if (startChar > endPosition) {

--- a/packages/graphqlsp/src/graphql/generateTypes.ts
+++ b/packages/graphqlsp/src/graphql/generateTypes.ts
@@ -60,49 +60,51 @@ export const generateTypedDocumentNodes = async (
   scalars: Record<string, unknown>,
   baseTypesPath: string
 ) => {
-  if (!schema) return;
+  try {
+    if (!schema) return;
 
-  const parts = outputFile.split('/');
-  parts.pop();
-  let basePath = path
-    .relative(parts.join('/'), baseTypesPath)
-    .replace('.ts', '');
-  // case where files are declared globally, we need to prefix with ./
-  if (basePath === '__generated__/baseGraphQLSP') {
-    basePath = './' + basePath;
-  }
+    const parts = outputFile.split('/');
+    parts.pop();
+    let basePath = path
+      .relative(parts.join('/'), baseTypesPath)
+      .replace('.ts', '');
+    // case where files are declared globally, we need to prefix with ./
+    if (basePath === '__generated__/baseGraphQLSP') {
+      basePath = './' + basePath;
+    }
 
-  const config = {
-    documents: [
-      {
-        location: 'operation.graphql',
-        document: parse(doc),
+    const config = {
+      documents: [
+        {
+          location: 'operation.graphql',
+          document: parse(doc),
+        },
+      ],
+      config: {
+        scalars,
+        avoidOptionals: false,
+        enumsAsTypes: true,
+        nonOptionalTypename: true,
+        namespacedImportName: 'Types',
       },
-    ],
-    config: {
-      scalars,
-      avoidOptionals: false,
-      enumsAsTypes: true,
-      nonOptionalTypename: true,
-      namespacedImportName: 'Types',
-    },
-    filename: outputFile,
-    schema: parse(printSchema(schema)),
-    plugins: [
-      { 'typescript-operations': {} },
-      { 'typed-document-node': {} },
-      { add: { content: `import * as Types from "${basePath}"` } },
-    ],
-    pluginMap: {
-      'typescript-operations': typescriptOperationsPlugin,
-      'typed-document-node': typedDocumentNodePlugin,
-      add: addPlugin,
-    },
-  };
+      filename: outputFile,
+      schema: parse(printSchema(schema)),
+      plugins: [
+        { 'typescript-operations': {} },
+        { 'typed-document-node': {} },
+        { add: { content: `import * as Types from "${basePath}"` } },
+      ],
+      pluginMap: {
+        'typescript-operations': typescriptOperationsPlugin,
+        'typed-document-node': typedDocumentNodePlugin,
+        add: addPlugin,
+      },
+    };
 
-  // @ts-ignore
-  const output = await codegen(config);
-  fs.writeFile(path.join(outputFile), output, 'utf8', err => {
-    console.error(err);
-  });
+    // @ts-ignore
+    const output = await codegen(config);
+    fs.writeFile(path.join(outputFile), output, 'utf8', err => {
+      console.error(err);
+    });
+  } catch (e) {}
 };

--- a/packages/graphqlsp/src/quickInfo.ts
+++ b/packages/graphqlsp/src/quickInfo.ts
@@ -34,7 +34,7 @@ export function getGraphQLQuickInfo(
 
     const hoverInfo = getHoverInformation(
       schema.current,
-      resolveTemplate(node, filename, info),
+      resolveTemplate(node, filename, info).combinedText,
       new Cursor(foundToken.line, foundToken.start)
     );
 


### PR DESCRIPTION
Partially resolves #72 

This avoids us polluting the LSP with diagnostics that go outside of the AST Node Range. An ideal solution here would be to indicate these on the `FragmentDefinition` itself, or TypeScript providing a way to tell us about a nested error.

This PR partially resolves the problem but introduces a new one where if folks add identifiers to the start of their document that we will convey the wrong information, however this is currently also present... After experimenting 😅 

Ideally during `resolve` we will start returning 

- the full text
- definition --> text
- ranges of definition --> text

This will allow us to translate and combine diagnostics effectively