### PR TITLE
allow specifying headers to get introspection

### DIFF
--- a/.changeset/cuddly-lobsters-return.md
+++ b/.changeset/cuddly-lobsters-return.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': minor
+---
+
+Allow specifying headers for fetching the introspection

--- a/packages/example/src/Pokemon.ts
+++ b/packages/example/src/Pokemon.ts
@@ -5,7 +5,6 @@ export const PokemonFields = gql`
   fragment pokemonFields on Pokemon {
     id
     name
-    ...someUnknownFragment
     attacks {
       fast {
         damage
@@ -18,9 +17,8 @@ export const PokemonFields = gql`
 export const WeakFields = gql`
   fragment weaknessFields on Pokemon {
     weaknesses
-    someUnknownField
   }
-` as typeof import('./Pokemon.generated').PokemonFieldsFragmentDoc;
+` as typeof import('./Pokemon.generated').WeaknessFieldsFragmentDoc;
 
 export const Pokemon = (data: any) => {
   const pokemon = useFragment(PokemonFields, data);

--- a/packages/example/src/index.generated.ts
+++ b/packages/example/src/index.generated.ts
@@ -16,7 +16,6 @@ export type PokemonFieldsFragment = {
   __typename: 'Pokemon';
   id: string;
   name: string;
-  resistant?: Array<Types.PokemonType | null> | null;
   attacks?: {
     __typename: 'AttacksConnection';
     fast?: Array<{
@@ -27,9 +26,9 @@ export type PokemonFieldsFragment = {
   } | null;
 };
 
-export type MoreFieldsFragment = {
+export type WeaknessFieldsFragment = {
   __typename: 'Pokemon';
-  resistant?: Array<Types.PokemonType | null> | null;
+  weaknesses?: Array<Types.PokemonType | null> | null;
 };
 
 export type PoQueryVariables = Types.Exact<{
@@ -45,25 +44,6 @@ export type PoQuery = {
   } | null;
 };
 
-export const MoreFieldsFragmentDoc = {
-  kind: 'Document',
-  definitions: [
-    {
-      kind: 'FragmentDefinition',
-      name: { kind: 'Name', value: 'moreFields' },
-      typeCondition: {
-        kind: 'NamedType',
-        name: { kind: 'Name', value: 'Pokemon' },
-      },
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [
-          { kind: 'Field', name: { kind: 'Name', value: 'resistant' } },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<MoreFieldsFragment, unknown>;
 export const PokemonFieldsFragmentDoc = {
   kind: 'Document',
   definitions: [
@@ -79,10 +59,6 @@ export const PokemonFieldsFragmentDoc = {
         selections: [
           { kind: 'Field', name: { kind: 'Name', value: 'id' } },
           { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-          {
-            kind: 'FragmentSpread',
-            name: { kind: 'Name', value: 'moreFields' },
-          },
           {
             kind: 'Field',
             name: { kind: 'Name', value: 'attacks' },
@@ -109,9 +85,14 @@ export const PokemonFieldsFragmentDoc = {
         ],
       },
     },
+  ],
+} as unknown as DocumentNode<PokemonFieldsFragment, unknown>;
+export const WeaknessFieldsFragmentDoc = {
+  kind: 'Document',
+  definitions: [
     {
       kind: 'FragmentDefinition',
-      name: { kind: 'Name', value: 'moreFields' },
+      name: { kind: 'Name', value: 'weaknessFields' },
       typeCondition: {
         kind: 'NamedType',
         name: { kind: 'Name', value: 'Pokemon' },
@@ -119,12 +100,12 @@ export const PokemonFieldsFragmentDoc = {
       selectionSet: {
         kind: 'SelectionSet',
         selections: [
-          { kind: 'Field', name: { kind: 'Name', value: 'resistant' } },
+          { kind: 'Field', name: { kind: 'Name', value: 'weaknesses' } },
         ],
       },
     },
   ],
-} as unknown as DocumentNode<PokemonFieldsFragment, unknown>;
+} as unknown as DocumentNode<WeaknessFieldsFragment, unknown>;
 export const PokDocument = {
   kind: 'Document',
   definitions: [
@@ -143,8 +124,8 @@ export const PokDocument = {
               selections: [
                 { kind: 'Field', name: { kind: 'Name', value: 'id' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                { kind: 'Field', name: { kind: 'Name', value: '__typename' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'fleeRate' } },
+                { kind: 'Field', name: { kind: 'Name', value: '__typename' } },
               ],
             },
           },

--- a/packages/example/src/index.ts
+++ b/packages/example/src/index.ts
@@ -7,8 +7,7 @@ const PokemonsQuery = gql`
       id
       name
       fleeRate
-
-      __typenam
+      __typename
     }
   }
 

--- a/packages/graphqlsp/README.md
+++ b/packages/graphqlsp/README.md
@@ -41,7 +41,8 @@ when on a TypeScript file or adding a file like [this](https://github.com/0no-co
 
 ### Configuration
 
-- `schema` allows you to specify a url, `.json` or `.graphql` file as your schema
+- `schema` allows you to specify a url, `.json` or `.graphql` file as your schema. If you need to specify headers for your introspection
+  you can opt into the object notation i.e. `{ "schema": { "url": "x", "headers": { "Authorization": "y" } }}`
 - `disableTypegen` disables type-generation in general
 - `scalars` allows you to pass an object of scalars that we'll feed into `graphql-code-generator`
 - `extraTypes` allows you to specify imports or declare types to help with `scalar` definitions

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4334,7 +4334,6 @@ packages:
     resolution: {directory: packages/graphqlsp, type: directory}
     id: file:packages/graphqlsp
     name: '@0no-co/graphqlsp'
-    version: 0.7.2
     dependencies:
       '@graphql-codegen/add': 4.0.1(graphql@16.6.0)
       '@graphql-codegen/core': 3.1.0(graphql@16.6.0)


### PR DESCRIPTION
Main reasoning for allowing it to be in JSON is that development are often not real secrets and when `http` is leveraged this seems redundant for the env. When it's really needed folks can opt into the file-based approach.

Resolve #85 