### PR TITLE
catch expression statements correctly

### DIFF
--- a/.changeset/small-pots-boil.md
+++ b/.changeset/small-pots-boil.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Catch expression statements

--- a/packages/example/src/index.generated.ts
+++ b/packages/example/src/index.generated.ts
@@ -1,6 +1,8 @@
 import * as Types from '../__generated__/baseGraphQLSP';
 import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
-export type PokQueryVariables = Types.Exact<{ [key: string]: never }>;
+export type PokQueryVariables = Types.Exact<{
+  limit: Types.Scalars['Int']['input'];
+}>;
 
 export type PokQuery = {
   __typename: 'Query';
@@ -122,12 +124,35 @@ export const PokDocument = {
       kind: 'OperationDefinition',
       operation: 'query',
       name: { kind: 'Name', value: 'Pok' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {
+            kind: 'Variable',
+            name: { kind: 'Name', value: 'limit' },
+          },
+          type: {
+            kind: 'NonNullType',
+            type: { kind: 'NamedType', name: { kind: 'Name', value: 'Int' } },
+          },
+        },
+      ],
       selectionSet: {
         kind: 'SelectionSet',
         selections: [
           {
             kind: 'Field',
             name: { kind: 'Name', value: 'pokemons' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'limit' },
+                value: {
+                  kind: 'Variable',
+                  name: { kind: 'Name', value: 'limit' },
+                },
+              },
+            ],
             selectionSet: {
               kind: 'SelectionSet',
               selections: [

--- a/packages/example/src/index.ts
+++ b/packages/example/src/index.ts
@@ -1,12 +1,13 @@
 import { gql, createClient } from '@urql/core';
 import { Pokemon, PokemonFields, WeakFields } from './Pokemon';
 
-const PokemonsQuery = gql`
-  query Pok {
-    pokemons {
+const x = gql`
+  query Pok($limit: Int!) {
+    pokemons(limit: $limit) {
       id
       name
       fleeRate
+      classification
       ...pokemonFields
       ...weaknessFields
       __typename
@@ -20,15 +21,6 @@ const PokemonsQuery = gql`
 const client = createClient({
   url: '',
 });
-
-client
-  .query(PokemonsQuery, {})
-  .toPromise()
-  .then(result => {
-    const fastAttacks = result.data?.pokemons?.map(
-      pokemon => pokemon?.attacks?.fast
-    );
-  });
 
 const PokemonQuery = gql`
   query Po($id: ID!) {

--- a/packages/graphqlsp/src/diagnostics.ts
+++ b/packages/graphqlsp/src/diagnostics.ts
@@ -1,6 +1,8 @@
 import ts from 'typescript/lib/tsserverlibrary';
 import {
   ImportTypeNode,
+  isAsExpression,
+  isExpressionStatement,
   isImportTypeNode,
   isNamedImportBindings,
   isNamespaceImport,
@@ -83,7 +85,20 @@ export function getGraphQLDiagnostics(
       );
       const lines = text.split('\n');
 
-      let startingPosition = node.pos + (tagTemplate.length + 1);
+      let isExpression = false;
+      if (isAsExpression(node.parent)) {
+        if (isExpressionStatement(node.parent.parent)) {
+          isExpression = true;
+        }
+      } else {
+        if (isExpressionStatement(node.parent)) {
+          isExpression = true;
+        }
+      }
+      // When we are dealing with a plain gql statement we have to add two these can be recognised
+      // by the fact that the parent is an expressionStatement
+      let startingPosition =
+        node.pos + (tagTemplate.length + (isExpression ? 2 : 1));
       const endPosition = startingPosition + node.getText().length;
       const graphQLDiagnostics = getDiagnostics(text, schema.current)
         .map(x => {


### PR DESCRIPTION
When the template-expression is not caught in a variable i..e when the parent is an expression statement we have to add 2

fixes #93 