### PR TITLE
fix `shouldCheckForColocatedFragments` option

### DIFF
--- a/.changeset/empty-planes-behave.md
+++ b/.changeset/empty-planes-behave.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Fix setting `shouldCheckForColocatedFragments` to `false` falling back to `true`

--- a/packages/graphqlsp/src/diagnostics.ts
+++ b/packages/graphqlsp/src/diagnostics.ts
@@ -48,7 +48,7 @@ export function getGraphQLDiagnostics(
   const tagTemplate = info.config.template || 'gql';
   const scalars = info.config.scalars || {};
   const shouldCheckForColocatedFragments =
-    info.config.shouldCheckForColocatedFragments || true;
+    info.config.shouldCheckForColocatedFragments ?? true;
 
   let source = getSource(info, filename);
   if (!source) return undefined;


### PR DESCRIPTION
When setting `shouldCheckForColocatedFragments: false` it will still fall back to `true` with the OR `||` check.