### PR TITLE
fix(template-resolution): resolve interpolated parsed fragments

### DIFF
--- a/.changeset/fresh-grapes-melt.md
+++ b/.changeset/fresh-grapes-melt.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Resolve parsed AST nodes being interpolated into an operation


### PR DESCRIPTION
If someone decided to import from `x.generated` they would be importing a parsed AST-node which would fail resolution, this now works like interpolating stringified fragments.

Resolves #102 