### PR TITLE
fix: adjust documentation display

### DIFF
--- a/.changeset/bright-news-agree.md
+++ b/.changeset/bright-news-agree.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Adjust documentation display

--- a/packages/example/src/Pokemon.ts
+++ b/packages/example/src/Pokemon.ts
@@ -1,5 +1,5 @@
 import { TypedDocumentNode } from '@graphql-typed-document-node/core';
-import { gql } from '@urql/core';
+import { createClient, gql } from '@urql/core';
 
 export const PokemonFields = gql`
   fragment pokemonFields on Pokemon {

--- a/packages/example/src/index.ts
+++ b/packages/example/src/index.ts
@@ -15,5 +15,5 @@ client
   .query(PokemonQuery, { id: '' })
   .toPromise()
   .then(result => {
-    result.data?.pokemon;
+    result.data?.pokemons;
   });

--- a/packages/graphqlsp/src/quickInfo.ts
+++ b/packages/graphqlsp/src/quickInfo.ts
@@ -11,6 +11,7 @@ import {
 import { resolveTemplate } from './ast/resolve';
 import { getToken } from './ast/token';
 import { Cursor } from './ast/cursor';
+import { Logger } from '.';
 
 export function getGraphQLQuickInfo(
   filename: string,
@@ -18,6 +19,8 @@ export function getGraphQLQuickInfo(
   schema: { current: GraphQLSchema | null },
   info: ts.server.PluginCreateInfo
 ): ts.QuickInfo | undefined {
+  const logger: Logger = (msg: string) =>
+    info.project.projectService.logger.info(`[GraphQLSP] ${msg}`);
   const tagTemplate = info.config.template || 'gql';
   const isCallExpression = info.config.templateIsCallExpression ?? false;
 
@@ -51,10 +54,10 @@ export function getGraphQLQuickInfo(
         start: cursorPosition,
         length: 1,
       },
-      kindModifiers: '',
-      displayParts: Array.isArray(hoverInfo)
-        ? hoverInfo.map(item => ({ kind: '', text: item as string }))
-        : [{ kind: '', text: hoverInfo as string }],
+      kindModifiers: 'text',
+      documentation: Array.isArray(hoverInfo)
+        ? hoverInfo.map(item => ({ kind: 'text', text: item as string }))
+        : [{ kind: 'text', text: hoverInfo as string }],
     };
   } else if (ts.isTaggedTemplateExpression(node)) {
     const { template, tag } = node;
@@ -87,16 +90,16 @@ export function getGraphQLQuickInfo(
     );
 
     return {
-      kind: ts.ScriptElementKind.string,
+      kind: ts.ScriptElementKind.label,
       textSpan: {
         start: cursorPosition,
         length: 1,
       },
-      kindModifiers: '',
-      displayParts: Array.isArray(hoverInfo)
-        ? hoverInfo.map(item => ({ kind: '', text: item as string }))
-        : [{ kind: '', text: hoverInfo as string }],
-    };
+      kindModifiers: 'text',
+      documentation: Array.isArray(hoverInfo)
+        ? hoverInfo.map(item => ({ kind: 'text', text: item as string }))
+        : [{ kind: 'text', text: hoverInfo as string }],
+    } as ts.QuickInfo;
   } else {
     return undefined;
   }

--- a/test/e2e/client-preset.test.ts
+++ b/test/e2e/client-preset.test.ts
@@ -148,7 +148,7 @@ describe('Fragment + operations', () => {
 
     expect(res).toBeDefined();
     expect(typeof res?.body).toEqual('object');
-    expect(res?.body.displayString).toEqual(`Pokemon.name: String!`);
+    expect(res?.body.documentation).toEqual(`Pokemon.name: String!`);
   }, 30000);
 
   it('gives quick-info with documents', async () => {
@@ -174,7 +174,7 @@ describe('Fragment + operations', () => {
 
     expect(res).toBeDefined();
     expect(typeof res?.body).toEqual('object');
-    expect(res?.body.displayString).toEqual(
+    expect(res?.body.documentation).toEqual(
       `Query.pokemons: [Pokemon]
 
 List out all Pokémon, optionally in pages`

--- a/test/e2e/combinations.test.ts
+++ b/test/e2e/combinations.test.ts
@@ -120,7 +120,7 @@ describe('Fragment + operations', () => {
 
     expect(res).toBeDefined();
     expect(typeof res?.body).toEqual('object');
-    expect(res?.body.displayString).toEqual(
+    expect(res?.body.documentation).toEqual(
       `Query.posts: [Post]\n\nList out all posts`
     );
   }, 30000);

--- a/test/e2e/graphqlsp.test.ts
+++ b/test/e2e/graphqlsp.test.ts
@@ -131,8 +131,8 @@ describe('simple', () => {
       .find(resp => resp.type === 'response' && resp.command === 'quickinfo');
     expect(res).toBeDefined();
     expect(typeof res?.body).toEqual('object');
-    expect(res?.body.displayString).toEqual(`Query.posts: [Post]
-
-List out all posts`);
+    expect(res?.body.documentation).toEqual(
+      `Query.posts: [Post]\n\nList out all posts`
+    );
   }, 7500);
 });


### PR DESCRIPTION
Resolve #124 

There are probably more possible improvements, looking at what it produces from an urql TSDoc...

```json
  "body": {
    "kind": "alias",
    "kindModifiers": "declare",
    "start": {
      "line": 39,
      "offset": 1
    },
    "end": {
      "line": 39,
      "offset": 13
    },
    "displayString": "(alias) createClient(opts: ClientOptions): Client\nimport createClient",
    "documentation": [
      {
        "text": "Accepts `ClientOptions` and creates a `Client`.",
        "kind": "text"
      }
    ],
    "tags": [
      {
        "name": "param",
        "text": [
          {
            "text": "opts",
            "kind": "parameterName"
          },
          {
            "text": " ",
            "kind": "space"
          },
          {
            "text": "- A ",
            "kind": "text"
          },
          {
            "text": "{@link ",
            "kind": "link"
          },
          {
            "text": "ClientOptions",
            "kind": "linkName",
            "target": {
              "file": "/Users/jovi/Documents/SideProjects/GraphQLSP/node_modules/.pnpm/@urql+core@3.2.2_graphql@16.8.1/node_modules/@urql/core/dist/urql-core-chunk.d.ts",
              "start": {
                "line": 12,
                "offset": 1
              },
              "end": {
                "line": 133,
                "offset": 2
              }
            }
          },
          {
            "text": "}",
            "kind": "link"
          },
          {
            "text": " objects with options for the `Client`.",
            "kind": "text"
          }
        ]
      },
      {
        "name": "returns",
        "text": [
          {
            "text": "A ",
            "kind": "text"
          },
          {
            "text": "{@link ",
            "kind": "link"
          },
          {
            "text": "Client",
            "kind": "linkName",
            "target": {
              "file": "/Users/jovi/Documents/SideProjects/GraphQLSP/node_modules/.pnpm/@urql+core@3.2.2_graphql@16.8.1/node_modules/@urql/core/dist/urql-core-chunk.d.ts",
              "start": {
                "line": 440,
                "offset": 15
              },
              "end": {
                "line": 440,
                "offset": 58
              }
            }
          },
          {
            "text": "}",
            "kind": "link"
          },
          {
            "text": " instantiated with `opts`.",
            "kind": "text"
          }
        ]
      }
    ]
  }
```