### PR TITLE
feat: use internal suggestions

### DIFF
--- a/.changeset/hip-poems-remain.md
+++ b/.changeset/hip-poems-remain.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': minor
+---
+
+Use our internal suggestions algo for better arugments and spread-suggestions

--- a/packages/graphqlsp/src/autoComplete.ts
+++ b/packages/graphqlsp/src/autoComplete.ts
@@ -65,7 +65,7 @@ export function getGraphQLCompletions(
 
     const queryText = node.arguments[0].getText();
     const fragments = getAllFragments(filename, node, info);
-    const cursor = new Cursor(foundToken.line, foundToken.start);
+    const cursor = new Cursor(foundToken.line, foundToken.start - 1);
     const text = `${queryText}\m${fragments.map(x => print(x)).join('\n')}`;
 
     const [suggestions, spreadSuggestions] = getSuggestionsInternal(
@@ -129,7 +129,7 @@ export function getGraphQLCompletions(
 
     foundToken.line = foundToken.line + amountOfLines;
 
-    const cursor = new Cursor(foundToken.line, foundToken.start);
+    const cursor = new Cursor(foundToken.line, foundToken.start - 1);
 
     const [suggestions, spreadSuggestions] = getSuggestionsInternal(
       schema.current,

--- a/packages/graphqlsp/src/autoComplete.ts
+++ b/packages/graphqlsp/src/autoComplete.ts
@@ -11,7 +11,13 @@ import {
   CharacterStream,
   ContextToken,
 } from 'graphql-language-service';
-import { FragmentDefinitionNode, GraphQLSchema, Kind, parse } from 'graphql';
+import {
+  FragmentDefinitionNode,
+  GraphQLSchema,
+  Kind,
+  parse,
+  print,
+} from 'graphql';
 
 import {
   bubbleUpCallExpression,
@@ -31,6 +37,9 @@ export function getGraphQLCompletions(
   schema: { current: GraphQLSchema | null },
   info: ts.server.PluginCreateInfo
 ): ts.WithMetadata<ts.CompletionInfo> | undefined {
+  const logger: any = (msg: string) =>
+    info.project.projectService.logger.info(`[GraphQLSP] ${msg}`);
+
   const tagTemplate = info.config.template || 'gql';
   const isCallExpression = info.config.templateIsCallExpression ?? false;
 
@@ -57,31 +66,44 @@ export function getGraphQLCompletions(
     const queryText = node.arguments[0].getText();
     const fragments = getAllFragments(filename, node, info);
     const cursor = new Cursor(foundToken.line, foundToken.start);
-    const items = getAutocompleteSuggestions(
+    const text = `${queryText}\m${fragments.map(x => print(x)).join('\n')}`;
+
+    const [suggestions, spreadSuggestions] = getSuggestionsInternal(
       schema.current,
-      queryText,
-      cursor,
-      undefined,
-      fragments
+      text,
+      cursor
     );
 
     return {
       isGlobalCompletion: false,
       isMemberCompletion: false,
       isNewIdentifierLocation: false,
-      entries: items.map(suggestion => ({
-        ...suggestion,
-        kind: ts.ScriptElementKind.variableElement,
-        name: suggestion.label,
-        kindModifiers: 'declare',
-        sortText: suggestion.sortText || '0',
-        labelDetails: {
-          detail: suggestion.type
-            ? ' ' + suggestion.type?.toString()
-            : undefined,
-          description: suggestion.documentation,
-        },
-      })),
+      entries: [
+        ...suggestions.map(suggestion => ({
+          ...suggestion,
+          kind: ts.ScriptElementKind.variableElement,
+          name: suggestion.label,
+          kindModifiers: 'declare',
+          sortText: suggestion.sortText || '0',
+          labelDetails: {
+            detail: suggestion.type
+              ? ' ' + suggestion.type?.toString()
+              : undefined,
+            description: suggestion.documentation,
+          },
+        })),
+        ...spreadSuggestions.map(suggestion => ({
+          ...suggestion,
+          kind: ts.ScriptElementKind.variableElement,
+          name: suggestion.label,
+          insertText: '...' + suggestion.label,
+          kindModifiers: 'declare',
+          sortText: '0',
+          labelDetails: {
+            description: suggestion.documentation,
+          },
+        })),
+      ],
     };
   } else if (ts.isTaggedTemplateExpression(node)) {
     const { template, tag } = node;

--- a/packages/graphqlsp/src/quickInfo.ts
+++ b/packages/graphqlsp/src/quickInfo.ts
@@ -42,7 +42,7 @@ export function getGraphQLQuickInfo(
     if (!schema.current || !foundToken) return undefined;
 
     const queryText = node.arguments[0].getText();
-    const cursor = new Cursor(foundToken.line, foundToken.start);
+    const cursor = new Cursor(foundToken.line, foundToken.start - 1);
     const hoverInfo = getHoverInformation(schema.current, queryText, cursor);
 
     return {
@@ -83,7 +83,7 @@ export function getGraphQLQuickInfo(
     const hoverInfo = getHoverInformation(
       schema.current,
       text,
-      new Cursor(foundToken.line, foundToken.start)
+      new Cursor(foundToken.line, foundToken.start - 1)
     );
 
     return {


### PR DESCRIPTION
Resolves #111
fixes #127
fixes #130 

This introduces two changes, first we use our internal suggestions algorithm which filters out fragments and fields that are already used (unless using an alias). Secondly it decrements the starting token for the col to improve suggestions for narrow spacing i.e. `queryField()` and `fragment x on Y {}`

<img width="684" alt="A fragment being typed with only closed curlies but it still shows the correct field-suggestions which was bugged before as it thought we were after the closing curly and would suggest root-fields" src="https://github.com/0no-co/GraphQLSP/assets/17125876/af41818e-5b38-481c-8e40-82fb8359e29b">

<img width="665" alt="A query named `todos` where we have an opening and closing brace, our cursor is in-between it and it correctly suggests to either use limit or skip" src="https://github.com/0no-co/GraphQLSP/assets/17125876/5994a8ec-617b-4d05-840b-c061a2067cf3">
