### PR TITLE
feat: add missing fragment spread warnings

### DIFF
--- a/.changeset/mean-news-unite.md
+++ b/.changeset/mean-news-unite.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': minor
+---
+
+Warn when an import defines a fragment that is unused in the current file

--- a/packages/example-external-generator/src/index.tsx
+++ b/packages/example-external-generator/src/index.tsx
@@ -20,7 +20,6 @@ const PokemonQuery = graphql(`
       }
       name
       __typename
-
     }
   }
 `);

--- a/packages/example-external-generator/src/index.tsx
+++ b/packages/example-external-generator/src/index.tsx
@@ -20,6 +20,7 @@ const PokemonQuery = graphql(`
       }
       name
       __typename
+
     }
   }
 `);

--- a/packages/example-external-generator/tsconfig.json
+++ b/packages/example-external-generator/tsconfig.json
@@ -5,7 +5,7 @@
         "name": "@0no-co/graphqlsp",
         "schema": "./schema.graphql",
         "disableTypegen": true,
-        "shouldCheckForColocatedFragments": false,
+        "shouldCheckForColocatedFragments": true,
         "template": "graphql",
         "templateIsCallExpression": true,
         "trackFieldUsage": true

--- a/packages/graphqlsp/src/ast/index.ts
+++ b/packages/graphqlsp/src/ast/index.ts
@@ -55,14 +55,15 @@ export function findAllTaggedTemplateNodes(
 export function findAllCallExpressions(
   sourceFile: ts.SourceFile,
   template: string,
-  info: ts.server.PluginCreateInfo
+  info: ts.server.PluginCreateInfo,
+  shouldSearchFragments: boolean = true
 ): {
   nodes: Array<ts.NoSubstitutionTemplateLiteral>;
   fragments: Array<FragmentDefinitionNode>;
 } {
   const result: Array<ts.NoSubstitutionTemplateLiteral> = [];
   let fragments: Array<FragmentDefinitionNode> = [];
-  let hasTriedToFindFragments = false;
+  let hasTriedToFindFragments = shouldSearchFragments ? false : true;
   function find(node: ts.Node) {
     if (ts.isCallExpression(node) && node.expression.getText() === template) {
       if (!hasTriedToFindFragments) {

--- a/packages/graphqlsp/src/autoComplete.ts
+++ b/packages/graphqlsp/src/autoComplete.ts
@@ -64,10 +64,10 @@ export function getGraphQLCompletions(
     const foundToken = getToken(node.arguments[0], cursorPosition);
     if (!schema.current || !foundToken) return undefined;
 
-    const queryText = node.arguments[0].getText();
+    const queryText = node.arguments[0].getText().slice(1, -1);
     const fragments = getAllFragments(filename, node, info);
 
-    text = `${queryText}\m${fragments.map(x => print(x)).join('\n')}`;
+    text = `${queryText}\n${fragments.map(x => print(x)).join('\n')}`;
     cursor = new Cursor(foundToken.line, foundToken.start - 1);
   } else if (ts.isTaggedTemplateExpression(node)) {
     const { template, tag } = node;
@@ -151,7 +151,10 @@ export function getSuggestionsInternal(
     fragments = parsed.definitions.filter(
       x => x.kind === Kind.FRAGMENT_DEFINITION
     ) as Array<FragmentDefinitionNode>;
-  } catch (e) {}
+  } catch (e) {
+    console.log('[GraphQLSP] ', e);
+  }
+  console.log('fraggers', fragments.map(x => print(x)).join('\n'));
 
   let suggestions = getAutocompleteSuggestions(schema, queryText, cursor);
   let spreadSuggestions = getSuggestionsForFragmentSpread(
@@ -161,6 +164,7 @@ export function getSuggestionsInternal(
     queryText,
     fragments
   );
+  console.log(JSON.stringify(spreadSuggestions, null, 2));
 
   const state =
     token.state.kind === 'Invalid' ? token.state.prevState : token.state;

--- a/packages/graphqlsp/src/checkImports.ts
+++ b/packages/graphqlsp/src/checkImports.ts
@@ -126,8 +126,14 @@ export const getColocatedFragmentNames = (
   names: Array<string>;
   nameToLoc: Record<string, { start: number; length: number }>;
 } => {
+  const shouldCheckForColocatedFragments =
+    info.config.shouldCheckForColocatedFragments ?? false;
+  if (!shouldCheckForColocatedFragments) return { names: [], nameToLoc: {} };
+
   const imports = findAllImports(source);
   const fragmentNames: Set<string> = new Set();
+  // TODO: this should be a module-specifier that maps to a loc and a list of fragment-names
+  // this to support duplicate fragment-names and showing the warning on the module-specifier.
   const nameToLoc: Record<string, { start: number; length: number }> = {};
 
   if (imports.length) {
@@ -149,7 +155,7 @@ export const getColocatedFragmentNames = (
           const fragmentsForImport = getFragmentsInSource(externalSource, info);
           fragmentsForImport.forEach(fragment => {
             nameToLoc[fragment.name.value] = {
-              start: imp.importClause!.getStart(),
+              start: imp.moduleSpecifier.getStart(),
               length: imp.importClause!.getText().length,
             };
             fragmentNames.add(fragment.name.value);

--- a/packages/graphqlsp/src/checkImports.ts
+++ b/packages/graphqlsp/src/checkImports.ts
@@ -126,10 +126,6 @@ export const getColocatedFragmentNames = (
   names: Array<string>;
   nameToLoc: Record<string, { start: number; length: number }>;
 } => {
-  const shouldCheckForColocatedFragments =
-    info.config.shouldCheckForColocatedFragments ?? false;
-  if (!shouldCheckForColocatedFragments) return { names: [], nameToLoc: {} };
-
   const imports = findAllImports(source);
   const fragmentNames: Set<string> = new Set();
   // TODO: this should be a module-specifier that maps to a loc and a list of fragment-names

--- a/packages/graphqlsp/src/diagnostics.ts
+++ b/packages/graphqlsp/src/diagnostics.ts
@@ -315,6 +315,7 @@ const runDiagnostics = (
       nodes as ts.NoSubstitutionTemplateLiteral[],
       info
     );
+
     const { names: fragmentNames, nameToLoc } = getColocatedFragmentNames(
       source,
       info
@@ -332,6 +333,7 @@ const runDiagnostics = (
     });
 
     const missingFragments = fragmentNames.filter(x => !usedFragments.has(x));
+
     const fragmentDiagnostics: ts.Diagnostic[] = missingFragments.map(
       unusedFragment => {
         const loc = nameToLoc[unusedFragment];
@@ -341,7 +343,7 @@ const runDiagnostics = (
           start: loc.start,
           category: ts.DiagnosticCategory.Warning,
           code: MISSING_FRAGMENT_CODE,
-          messageText: `Missing fragment spread "${unusedFragment}"`,
+          messageText: `Unused co-located fragment definition "${unusedFragment}"`,
         };
       }
     );

--- a/test/e2e/client-preset.test.ts
+++ b/test/e2e/client-preset.test.ts
@@ -233,134 +233,36 @@ List out all Pokémon, optionally in pages`
     expect(res?.body.entries).toMatchInlineSnapshot(`
       [
         {
-          "kind": "var",
-          "kindModifiers": "declare",
-          "labelDetails": {
-            "detail": " AttacksConnection",
+          "kind": "string",
+          "kindModifiers": "",
+          "name": "\\\\n  fragment pokemonFields on Pokemon {\\\\n    id\\\\n    name\\\\n    attacks {\\\\n      fast {\\\\n        damage\\\\n        name\\\\n      }\\\\n    }\\\\n  }\\\\n",
+          "replacementSpan": {
+            "end": {
+              "line": 9,
+              "offset": 1,
+            },
+            "start": {
+              "line": 3,
+              "offset": 39,
+            },
           },
-          "name": "attacks",
-          "sortText": "0attacks",
+          "sortText": "11",
         },
         {
-          "kind": "var",
-          "kindModifiers": "declare",
-          "labelDetails": {
-            "detail": " [EvolutionRequirement]",
+          "kind": "string",
+          "kindModifiers": "",
+          "name": "\\\\n  query Pok($limit: Int!) {\\\\n    pokemons(limit: $limit) {\\\\n      id\\\\n      name\\\\n      fleeRate\\\\n      classification\\\\n      ...pokemonFields\\\\n      ...weaknessFields\\\\n      __typename\\\\n    }\\\\n  }\\\\n",
+          "replacementSpan": {
+            "end": {
+              "line": 9,
+              "offset": 1,
+            },
+            "start": {
+              "line": 3,
+              "offset": 39,
+            },
           },
-          "name": "evolutionRequirements",
-          "sortText": "2evolutionRequirements",
-        },
-        {
-          "kind": "var",
-          "kindModifiers": "declare",
-          "labelDetails": {
-            "detail": " [Pokemon]",
-          },
-          "name": "evolutions",
-          "sortText": "3evolutions",
-        },
-        {
-          "kind": "var",
-          "kindModifiers": "declare",
-          "labelDetails": {
-            "description": "Likelihood of an attempt to catch a Pokémon to fail.",
-            "detail": " Float",
-          },
-          "name": "fleeRate",
-          "sortText": "4fleeRate",
-        },
-        {
-          "kind": "var",
-          "kindModifiers": "declare",
-          "labelDetails": {
-            "detail": " PokemonDimension",
-          },
-          "name": "height",
-          "sortText": "5height",
-        },
-        {
-          "kind": "var",
-          "kindModifiers": "declare",
-          "labelDetails": {
-            "detail": " ID!",
-          },
-          "name": "id",
-          "sortText": "6id",
-        },
-        {
-          "kind": "var",
-          "kindModifiers": "declare",
-          "labelDetails": {
-            "description": "Maximum combat power a Pokémon may achieve at max level.",
-            "detail": " Int",
-          },
-          "name": "maxCP",
-          "sortText": "7maxCP",
-        },
-        {
-          "kind": "var",
-          "kindModifiers": "declare",
-          "labelDetails": {
-            "description": "Maximum health points a Pokémon may achieve at max level.",
-            "detail": " Int",
-          },
-          "name": "maxHP",
-          "sortText": "8maxHP",
-        },
-        {
-          "kind": "var",
-          "kindModifiers": "declare",
-          "labelDetails": {
-            "detail": " String!",
-          },
-          "name": "name",
-          "sortText": "9name",
-        },
-        {
-          "kind": "var",
-          "kindModifiers": "declare",
-          "labelDetails": {
-            "detail": " [PokemonType]",
-          },
-          "name": "resistant",
-          "sortText": "10resistant",
-        },
-        {
-          "kind": "var",
-          "kindModifiers": "declare",
-          "labelDetails": {
-            "detail": " [PokemonType]",
-          },
-          "name": "types",
-          "sortText": "11types",
-        },
-        {
-          "kind": "var",
-          "kindModifiers": "declare",
-          "labelDetails": {
-            "detail": " [PokemonType]",
-          },
-          "name": "weaknesses",
-          "sortText": "12weaknesses",
-        },
-        {
-          "kind": "var",
-          "kindModifiers": "declare",
-          "labelDetails": {
-            "detail": " PokemonDimension",
-          },
-          "name": "weight",
-          "sortText": "13weight",
-        },
-        {
-          "kind": "var",
-          "kindModifiers": "declare",
-          "labelDetails": {
-            "description": "The name of the current Object type at runtime.",
-            "detail": " String!",
-          },
-          "name": "__typename",
-          "sortText": "14__typename",
+          "sortText": "11",
         },
       ]
     `);
@@ -392,13 +294,13 @@ List out all Pokémon, optionally in pages`
           "code": 52003,
           "end": {
             "line": 2,
-            "offset": 17,
+            "offset": 37,
           },
           "start": {
             "line": 2,
-            "offset": 10,
+            "offset": 25,
           },
-          "text": "Missing fragment spread \\"pokemonFields\\"",
+          "text": "Unused co-located fragment definition(s) \\"pokemonFields\\" in './fragment'",
         },
       ]
     `);

--- a/test/e2e/fixture-project-client-preset/fixtures/fragment.ts
+++ b/test/e2e/fixture-project-client-preset/fixtures/fragment.ts
@@ -5,6 +5,7 @@ export const PokemonFields = graphql(`
     id
     name
     fleeRate
-      
   }
 `);
+
+export const Pokemon = () => {};

--- a/test/e2e/fixture-project-client-preset/fixtures/unused-fragment.ts
+++ b/test/e2e/fixture-project-client-preset/fixtures/unused-fragment.ts
@@ -1,0 +1,13 @@
+import { graphql } from './gql/gql';
+import { Pokemon } from './fragment';
+
+const x = graphql(`
+  query Pok($limit: Int!) {
+    pokemons(limit: $limit) {
+      id
+      name
+    }
+  }
+`);
+
+console.log(Pokemon);

--- a/test/e2e/fixture-project-client-preset/tsconfig.json
+++ b/test/e2e/fixture-project-client-preset/tsconfig.json
@@ -5,7 +5,7 @@
         "name": "@0no-co/graphqlsp",
         "schema": "./schema.graphql",
         "disableTypegen": true,
-        "shouldCheckForColocatedFragments": false,
+        "shouldCheckForColocatedFragments": true,
         "template": "graphql",
         "templateIsCallExpression": true
       }


### PR DESCRIPTION
This adds support for searching the imports for fragments, then it will check all the found fragments whether they are used in the GraphQL documents of the file you are working in. When we find unused fragments we will warn the user.

Resolves #153 