### PR TITLE
feat: Allow tadaOutputLocation to contain file target and switch output modes

### DIFF
--- a/.changeset/tough-birds-brush.md
+++ b/.changeset/tough-birds-brush.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': minor
+---
+
+Allow `tadaOutputLocation` to contain filename targets and switch between a `.d.ts` and `.ts` output mode.

--- a/packages/example-tada/introspection.ts
+++ b/packages/example-tada/introspection.ts
@@ -1,4 +1,25 @@
-export const introspection = {
+/** An IntrospectionQuery representation of your schema.
+ *
+ * @remarks
+ * This is an introspection of your schema saved as a file by GraphQLSP.
+ * You may import it to create a `graphql()` tag function with `gql.tada`
+ * by importing it and passing it to `initGraphQLTada<>()`.
+ *
+ * @example
+ * ```
+ * import { initGraphQLTada } from 'gql.tada';
+ * import { introspection } from './introspection';
+ *
+ * export const graphql = initGraphQLTada<{
+ *   introspection: typeof introspection;
+ *   scalars: {
+ *     DateTime: string;
+ *     Json: any;
+ *   };
+ * }>();
+ * ```
+ */
+const introspection = {
   __schema: {
     queryType: {
       name: 'Query',
@@ -7,1624 +28,418 @@ export const introspection = {
     subscriptionType: null,
     types: [
       {
-        kind: 'ENUM',
-        name: 'PokemonType',
-        description:
-          'Elemental property associated with either a Pokémon or one of their moves.',
-        fields: null,
-        inputFields: null,
-        interfaces: null,
-        enumValues: [
-          {
-            name: 'Grass',
-            description: null,
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'Poison',
-            description: null,
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'Fire',
-            description: null,
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'Flying',
-            description: null,
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'Water',
-            description: null,
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'Bug',
-            description: null,
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'Normal',
-            description: null,
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'Electric',
-            description: null,
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'Ground',
-            description: null,
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'Fairy',
-            description: null,
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'Fighting',
-            description: null,
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'Psychic',
-            description: null,
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'Rock',
-            description: null,
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'Steel',
-            description: null,
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'Ice',
-            description: null,
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'Ghost',
-            description: null,
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'Dragon',
-            description: null,
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'Dark',
-            description: null,
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-        ],
-        possibleTypes: null,
-      },
-      {
         kind: 'OBJECT',
         name: 'Attack',
-        description:
-          'Move a Pokémon can perform with the associated damage and type.',
         fields: [
           {
-            name: 'name',
-            description: null,
+            name: 'damage',
+            type: {
+              kind: 'SCALAR',
+              name: 'Int',
+              ofType: null,
+            },
             args: [],
+          },
+          {
+            name: 'name',
             type: {
               kind: 'SCALAR',
               name: 'String',
               ofType: null,
             },
-            isDeprecated: false,
-            deprecationReason: null,
+            args: [],
           },
           {
             name: 'type',
-            description: null,
-            args: [],
             type: {
               kind: 'ENUM',
               name: 'PokemonType',
               ofType: null,
             },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'damage',
-            description: null,
             args: [],
-            type: {
-              kind: 'SCALAR',
-              name: 'Int',
-              ofType: null,
-            },
-            isDeprecated: false,
-            deprecationReason: null,
           },
         ],
-        inputFields: null,
         interfaces: [],
-        enumValues: null,
-        possibleTypes: null,
-      },
-      {
-        kind: 'SCALAR',
-        name: 'String',
-        description:
-          'The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.',
-        fields: null,
-        inputFields: null,
-        interfaces: null,
-        enumValues: null,
-        possibleTypes: null,
       },
       {
         kind: 'SCALAR',
         name: 'Int',
-        description:
-          'The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.',
-        fields: null,
-        inputFields: null,
-        interfaces: null,
-        enumValues: null,
-        possibleTypes: null,
+      },
+      {
+        kind: 'SCALAR',
+        name: 'String',
+      },
+      {
+        kind: 'OBJECT',
+        name: 'AttacksConnection',
+        fields: [
+          {
+            name: 'fast',
+            type: {
+              kind: 'LIST',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'Attack',
+                ofType: null,
+              },
+            },
+            args: [],
+          },
+          {
+            name: 'special',
+            type: {
+              kind: 'LIST',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'Attack',
+                ofType: null,
+              },
+            },
+            args: [],
+          },
+        ],
+        interfaces: [],
       },
       {
         kind: 'OBJECT',
         name: 'EvolutionRequirement',
-        description:
-          'Requirement that prevents an evolution through regular means of levelling up.',
         fields: [
           {
             name: 'amount',
-            description: null,
-            args: [],
             type: {
               kind: 'SCALAR',
               name: 'Int',
               ofType: null,
             },
-            isDeprecated: false,
-            deprecationReason: null,
+            args: [],
           },
           {
             name: 'name',
-            description: null,
-            args: [],
             type: {
               kind: 'SCALAR',
               name: 'String',
               ofType: null,
             },
-            isDeprecated: false,
-            deprecationReason: null,
+            args: [],
           },
         ],
-        inputFields: null,
         interfaces: [],
-        enumValues: null,
-        possibleTypes: null,
-      },
-      {
-        kind: 'OBJECT',
-        name: 'PokemonDimension',
-        description: null,
-        fields: [
-          {
-            name: 'minimum',
-            description: null,
-            args: [],
-            type: {
-              kind: 'SCALAR',
-              name: 'String',
-              ofType: null,
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'maximum',
-            description: null,
-            args: [],
-            type: {
-              kind: 'SCALAR',
-              name: 'String',
-              ofType: null,
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-        ],
-        inputFields: null,
-        interfaces: [],
-        enumValues: null,
-        possibleTypes: null,
-      },
-      {
-        kind: 'OBJECT',
-        name: 'AttacksConnection',
-        description: null,
-        fields: [
-          {
-            name: 'fast',
-            description: null,
-            args: [],
-            type: {
-              kind: 'LIST',
-              name: null,
-              ofType: {
-                kind: 'OBJECT',
-                name: 'Attack',
-                ofType: null,
-              },
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'special',
-            description: null,
-            args: [],
-            type: {
-              kind: 'LIST',
-              name: null,
-              ofType: {
-                kind: 'OBJECT',
-                name: 'Attack',
-                ofType: null,
-              },
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-        ],
-        inputFields: null,
-        interfaces: [],
-        enumValues: null,
-        possibleTypes: null,
       },
       {
         kind: 'OBJECT',
         name: 'Pokemon',
-        description: null,
         fields: [
           {
-            name: 'id',
-            description: null,
-            args: [],
+            name: 'attacks',
             type: {
-              kind: 'NON_NULL',
-              name: null,
-              ofType: {
-                kind: 'SCALAR',
-                name: 'ID',
-                ofType: null,
-              },
+              kind: 'OBJECT',
+              name: 'AttacksConnection',
+              ofType: null,
             },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'name',
-            description: null,
             args: [],
-            type: {
-              kind: 'NON_NULL',
-              name: null,
-              ofType: {
-                kind: 'SCALAR',
-                name: 'String',
-                ofType: null,
-              },
-            },
-            isDeprecated: false,
-            deprecationReason: null,
           },
           {
             name: 'classification',
-            description: null,
-            args: [],
             type: {
               kind: 'SCALAR',
               name: 'String',
               ofType: null,
             },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'types',
-            description: null,
             args: [],
-            type: {
-              kind: 'LIST',
-              name: null,
-              ofType: {
-                kind: 'ENUM',
-                name: 'PokemonType',
-                ofType: null,
-              },
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'resistant',
-            description: null,
-            args: [],
-            type: {
-              kind: 'LIST',
-              name: null,
-              ofType: {
-                kind: 'ENUM',
-                name: 'PokemonType',
-                ofType: null,
-              },
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'weaknesses',
-            description: null,
-            args: [],
-            type: {
-              kind: 'LIST',
-              name: null,
-              ofType: {
-                kind: 'ENUM',
-                name: 'PokemonType',
-                ofType: null,
-              },
-            },
-            isDeprecated: false,
-            deprecationReason: null,
           },
           {
             name: 'evolutionRequirements',
-            description: null,
-            args: [],
             type: {
               kind: 'LIST',
-              name: null,
               ofType: {
                 kind: 'OBJECT',
                 name: 'EvolutionRequirement',
                 ofType: null,
               },
             },
-            isDeprecated: false,
-            deprecationReason: null,
+            args: [],
           },
           {
-            name: 'weight',
-            description: null,
-            args: [],
+            name: 'evolutions',
             type: {
-              kind: 'OBJECT',
-              name: 'PokemonDimension',
-              ofType: null,
+              kind: 'LIST',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'Pokemon',
+                ofType: null,
+              },
             },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'height',
-            description: null,
             args: [],
-            type: {
-              kind: 'OBJECT',
-              name: 'PokemonDimension',
-              ofType: null,
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'attacks',
-            description: null,
-            args: [],
-            type: {
-              kind: 'OBJECT',
-              name: 'AttacksConnection',
-              ofType: null,
-            },
-            isDeprecated: false,
-            deprecationReason: null,
           },
           {
             name: 'fleeRate',
-            description: 'Likelihood of an attempt to catch a Pokémon to fail.',
-            args: [],
             type: {
               kind: 'SCALAR',
               name: 'Float',
               ofType: null,
             },
-            isDeprecated: false,
-            deprecationReason: null,
+            args: [],
           },
           {
-            name: 'maxCP',
-            description:
-              'Maximum combat power a Pokémon may achieve at max level.',
-            args: [],
+            name: 'height',
             type: {
-              kind: 'SCALAR',
-              name: 'Int',
+              kind: 'OBJECT',
+              name: 'PokemonDimension',
               ofType: null,
             },
-            isDeprecated: false,
-            deprecationReason: null,
+            args: [],
           },
           {
-            name: 'maxHP',
-            description:
-              'Maximum health points a Pokémon may achieve at max level.',
-            args: [],
+            name: 'id',
             type: {
-              kind: 'SCALAR',
-              name: 'Int',
-              ofType: null,
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'evolutions',
-            description: null,
-            args: [],
-            type: {
-              kind: 'LIST',
-              name: null,
+              kind: 'NON_NULL',
               ofType: {
-                kind: 'OBJECT',
-                name: 'Pokemon',
+                kind: 'SCALAR',
+                name: 'ID',
                 ofType: null,
               },
             },
-            isDeprecated: false,
-            deprecationReason: null,
+            args: [],
+          },
+          {
+            name: 'maxCP',
+            type: {
+              kind: 'SCALAR',
+              name: 'Int',
+              ofType: null,
+            },
+            args: [],
+          },
+          {
+            name: 'maxHP',
+            type: {
+              kind: 'SCALAR',
+              name: 'Int',
+              ofType: null,
+            },
+            args: [],
+          },
+          {
+            name: 'name',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'SCALAR',
+                name: 'String',
+                ofType: null,
+              },
+            },
+            args: [],
+          },
+          {
+            name: 'resistant',
+            type: {
+              kind: 'LIST',
+              ofType: {
+                kind: 'ENUM',
+                name: 'PokemonType',
+                ofType: null,
+              },
+            },
+            args: [],
+          },
+          {
+            name: 'types',
+            type: {
+              kind: 'LIST',
+              ofType: {
+                kind: 'ENUM',
+                name: 'PokemonType',
+                ofType: null,
+              },
+            },
+            args: [],
+          },
+          {
+            name: 'weaknesses',
+            type: {
+              kind: 'LIST',
+              ofType: {
+                kind: 'ENUM',
+                name: 'PokemonType',
+                ofType: null,
+              },
+            },
+            args: [],
+          },
+          {
+            name: 'weight',
+            type: {
+              kind: 'OBJECT',
+              name: 'PokemonDimension',
+              ofType: null,
+            },
+            args: [],
           },
         ],
-        inputFields: null,
         interfaces: [],
-        enumValues: null,
-        possibleTypes: null,
-      },
-      {
-        kind: 'SCALAR',
-        name: 'ID',
-        description:
-          'The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `"4"`) or integer (such as `4`) input value will be accepted as an ID.',
-        fields: null,
-        inputFields: null,
-        interfaces: null,
-        enumValues: null,
-        possibleTypes: null,
       },
       {
         kind: 'SCALAR',
         name: 'Float',
-        description:
-          'The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).',
-        fields: null,
-        inputFields: null,
-        interfaces: null,
-        enumValues: null,
-        possibleTypes: null,
+      },
+      {
+        kind: 'SCALAR',
+        name: 'ID',
+      },
+      {
+        kind: 'OBJECT',
+        name: 'PokemonDimension',
+        fields: [
+          {
+            name: 'maximum',
+            type: {
+              kind: 'SCALAR',
+              name: 'String',
+              ofType: null,
+            },
+            args: [],
+          },
+          {
+            name: 'minimum',
+            type: {
+              kind: 'SCALAR',
+              name: 'String',
+              ofType: null,
+            },
+            args: [],
+          },
+        ],
+        interfaces: [],
+      },
+      {
+        kind: 'ENUM',
+        name: 'PokemonType',
+        enumValues: [
+          {
+            name: 'Bug',
+          },
+          {
+            name: 'Dark',
+          },
+          {
+            name: 'Dragon',
+          },
+          {
+            name: 'Electric',
+          },
+          {
+            name: 'Fairy',
+          },
+          {
+            name: 'Fighting',
+          },
+          {
+            name: 'Fire',
+          },
+          {
+            name: 'Flying',
+          },
+          {
+            name: 'Ghost',
+          },
+          {
+            name: 'Grass',
+          },
+          {
+            name: 'Ground',
+          },
+          {
+            name: 'Ice',
+          },
+          {
+            name: 'Normal',
+          },
+          {
+            name: 'Poison',
+          },
+          {
+            name: 'Psychic',
+          },
+          {
+            name: 'Rock',
+          },
+          {
+            name: 'Steel',
+          },
+          {
+            name: 'Water',
+          },
+        ],
       },
       {
         kind: 'OBJECT',
         name: 'Query',
-        description: null,
         fields: [
           {
-            name: 'pokemons',
-            description: 'List out all Pokémon, optionally in pages',
-            args: [
-              {
-                name: 'limit',
-                description: null,
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Int',
-                  ofType: null,
-                },
-                defaultValue: null,
-              },
-              {
-                name: 'skip',
-                description: null,
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Int',
-                  ofType: null,
-                },
-                defaultValue: null,
-              },
-            ],
-            type: {
-              kind: 'LIST',
-              name: null,
-              ofType: {
-                kind: 'OBJECT',
-                name: 'Pokemon',
-                ofType: null,
-              },
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
             name: 'pokemon',
-            description:
-              'Get a single Pokémon by its ID, a three character long identifier padded with zeroes',
+            type: {
+              kind: 'OBJECT',
+              name: 'Pokemon',
+              ofType: null,
+            },
             args: [
               {
                 name: 'id',
-                description: null,
                 type: {
                   kind: 'NON_NULL',
-                  name: null,
                   ofType: {
                     kind: 'SCALAR',
                     name: 'ID',
                     ofType: null,
                   },
                 },
-                defaultValue: null,
               },
             ],
+          },
+          {
+            name: 'pokemons',
             type: {
-              kind: 'OBJECT',
-              name: 'Pokemon',
-              ofType: null,
+              kind: 'LIST',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'Pokemon',
+                ofType: null,
+              },
             },
-            isDeprecated: false,
-            deprecationReason: null,
+            args: [
+              {
+                name: 'limit',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Int',
+                  ofType: null,
+                },
+              },
+              {
+                name: 'skip',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Int',
+                  ofType: null,
+                },
+              },
+            ],
           },
         ],
-        inputFields: null,
         interfaces: [],
-        enumValues: null,
-        possibleTypes: null,
       },
       {
         kind: 'SCALAR',
         name: 'Boolean',
-        description: 'The `Boolean` scalar type represents `true` or `false`.',
-        fields: null,
-        inputFields: null,
-        interfaces: null,
-        enumValues: null,
-        possibleTypes: null,
       },
       {
-        kind: 'OBJECT',
-        name: '__Schema',
-        description:
-          'A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.',
-        fields: [
-          {
-            name: 'description',
-            description: null,
-            args: [],
-            type: {
-              kind: 'SCALAR',
-              name: 'String',
-              ofType: null,
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'types',
-            description: 'A list of all types supported by this server.',
-            args: [],
-            type: {
-              kind: 'NON_NULL',
-              name: null,
-              ofType: {
-                kind: 'LIST',
-                name: null,
-                ofType: {
-                  kind: 'NON_NULL',
-                  name: null,
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: '__Type',
-                    ofType: null,
-                  },
-                },
-              },
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'queryType',
-            description: 'The type that query operations will be rooted at.',
-            args: [],
-            type: {
-              kind: 'NON_NULL',
-              name: null,
-              ofType: {
-                kind: 'OBJECT',
-                name: '__Type',
-                ofType: null,
-              },
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'mutationType',
-            description:
-              'If this server supports mutation, the type that mutation operations will be rooted at.',
-            args: [],
-            type: {
-              kind: 'OBJECT',
-              name: '__Type',
-              ofType: null,
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'subscriptionType',
-            description:
-              'If this server support subscription, the type that subscription operations will be rooted at.',
-            args: [],
-            type: {
-              kind: 'OBJECT',
-              name: '__Type',
-              ofType: null,
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'directives',
-            description: 'A list of all directives supported by this server.',
-            args: [],
-            type: {
-              kind: 'NON_NULL',
-              name: null,
-              ofType: {
-                kind: 'LIST',
-                name: null,
-                ofType: {
-                  kind: 'NON_NULL',
-                  name: null,
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: '__Directive',
-                    ofType: null,
-                  },
-                },
-              },
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-        ],
-        inputFields: null,
-        interfaces: [],
-        enumValues: null,
-        possibleTypes: null,
-      },
-      {
-        kind: 'OBJECT',
-        name: '__Type',
-        description:
-          'The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional `specifiedByUrl`, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.',
-        fields: [
-          {
-            name: 'kind',
-            description: null,
-            args: [],
-            type: {
-              kind: 'NON_NULL',
-              name: null,
-              ofType: {
-                kind: 'ENUM',
-                name: '__TypeKind',
-                ofType: null,
-              },
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'name',
-            description: null,
-            args: [],
-            type: {
-              kind: 'SCALAR',
-              name: 'String',
-              ofType: null,
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'description',
-            description: null,
-            args: [],
-            type: {
-              kind: 'SCALAR',
-              name: 'String',
-              ofType: null,
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'specifiedByUrl',
-            description: null,
-            args: [],
-            type: {
-              kind: 'SCALAR',
-              name: 'String',
-              ofType: null,
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'fields',
-            description: null,
-            args: [
-              {
-                name: 'includeDeprecated',
-                description: null,
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Boolean',
-                  ofType: null,
-                },
-                defaultValue: 'false',
-              },
-            ],
-            type: {
-              kind: 'LIST',
-              name: null,
-              ofType: {
-                kind: 'NON_NULL',
-                name: null,
-                ofType: {
-                  kind: 'OBJECT',
-                  name: '__Field',
-                  ofType: null,
-                },
-              },
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'interfaces',
-            description: null,
-            args: [],
-            type: {
-              kind: 'LIST',
-              name: null,
-              ofType: {
-                kind: 'NON_NULL',
-                name: null,
-                ofType: {
-                  kind: 'OBJECT',
-                  name: '__Type',
-                  ofType: null,
-                },
-              },
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'possibleTypes',
-            description: null,
-            args: [],
-            type: {
-              kind: 'LIST',
-              name: null,
-              ofType: {
-                kind: 'NON_NULL',
-                name: null,
-                ofType: {
-                  kind: 'OBJECT',
-                  name: '__Type',
-                  ofType: null,
-                },
-              },
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'enumValues',
-            description: null,
-            args: [
-              {
-                name: 'includeDeprecated',
-                description: null,
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Boolean',
-                  ofType: null,
-                },
-                defaultValue: 'false',
-              },
-            ],
-            type: {
-              kind: 'LIST',
-              name: null,
-              ofType: {
-                kind: 'NON_NULL',
-                name: null,
-                ofType: {
-                  kind: 'OBJECT',
-                  name: '__EnumValue',
-                  ofType: null,
-                },
-              },
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'inputFields',
-            description: null,
-            args: [
-              {
-                name: 'includeDeprecated',
-                description: null,
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Boolean',
-                  ofType: null,
-                },
-                defaultValue: 'false',
-              },
-            ],
-            type: {
-              kind: 'LIST',
-              name: null,
-              ofType: {
-                kind: 'NON_NULL',
-                name: null,
-                ofType: {
-                  kind: 'OBJECT',
-                  name: '__InputValue',
-                  ofType: null,
-                },
-              },
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'ofType',
-            description: null,
-            args: [],
-            type: {
-              kind: 'OBJECT',
-              name: '__Type',
-              ofType: null,
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-        ],
-        inputFields: null,
-        interfaces: [],
-        enumValues: null,
-        possibleTypes: null,
-      },
-      {
-        kind: 'ENUM',
-        name: '__TypeKind',
-        description:
-          'An enum describing what kind of type a given `__Type` is.',
-        fields: null,
-        inputFields: null,
-        interfaces: null,
-        enumValues: [
-          {
-            name: 'SCALAR',
-            description: 'Indicates this type is a scalar.',
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'OBJECT',
-            description:
-              'Indicates this type is an object. `fields` and `interfaces` are valid fields.',
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'INTERFACE',
-            description:
-              'Indicates this type is an interface. `fields`, `interfaces`, and `possibleTypes` are valid fields.',
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'UNION',
-            description:
-              'Indicates this type is a union. `possibleTypes` is a valid field.',
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'ENUM',
-            description:
-              'Indicates this type is an enum. `enumValues` is a valid field.',
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'INPUT_OBJECT',
-            description:
-              'Indicates this type is an input object. `inputFields` is a valid field.',
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'LIST',
-            description:
-              'Indicates this type is a list. `ofType` is a valid field.',
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'NON_NULL',
-            description:
-              'Indicates this type is a non-null. `ofType` is a valid field.',
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-        ],
-        possibleTypes: null,
-      },
-      {
-        kind: 'OBJECT',
-        name: '__Field',
-        description:
-          'Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.',
-        fields: [
-          {
-            name: 'name',
-            description: null,
-            args: [],
-            type: {
-              kind: 'NON_NULL',
-              name: null,
-              ofType: {
-                kind: 'SCALAR',
-                name: 'String',
-                ofType: null,
-              },
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'description',
-            description: null,
-            args: [],
-            type: {
-              kind: 'SCALAR',
-              name: 'String',
-              ofType: null,
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'args',
-            description: null,
-            args: [
-              {
-                name: 'includeDeprecated',
-                description: null,
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Boolean',
-                  ofType: null,
-                },
-                defaultValue: 'false',
-              },
-            ],
-            type: {
-              kind: 'NON_NULL',
-              name: null,
-              ofType: {
-                kind: 'LIST',
-                name: null,
-                ofType: {
-                  kind: 'NON_NULL',
-                  name: null,
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: '__InputValue',
-                    ofType: null,
-                  },
-                },
-              },
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'type',
-            description: null,
-            args: [],
-            type: {
-              kind: 'NON_NULL',
-              name: null,
-              ofType: {
-                kind: 'OBJECT',
-                name: '__Type',
-                ofType: null,
-              },
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'isDeprecated',
-            description: null,
-            args: [],
-            type: {
-              kind: 'NON_NULL',
-              name: null,
-              ofType: {
-                kind: 'SCALAR',
-                name: 'Boolean',
-                ofType: null,
-              },
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'deprecationReason',
-            description: null,
-            args: [],
-            type: {
-              kind: 'SCALAR',
-              name: 'String',
-              ofType: null,
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-        ],
-        inputFields: null,
-        interfaces: [],
-        enumValues: null,
-        possibleTypes: null,
-      },
-      {
-        kind: 'OBJECT',
-        name: '__InputValue',
-        description:
-          'Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.',
-        fields: [
-          {
-            name: 'name',
-            description: null,
-            args: [],
-            type: {
-              kind: 'NON_NULL',
-              name: null,
-              ofType: {
-                kind: 'SCALAR',
-                name: 'String',
-                ofType: null,
-              },
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'description',
-            description: null,
-            args: [],
-            type: {
-              kind: 'SCALAR',
-              name: 'String',
-              ofType: null,
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'type',
-            description: null,
-            args: [],
-            type: {
-              kind: 'NON_NULL',
-              name: null,
-              ofType: {
-                kind: 'OBJECT',
-                name: '__Type',
-                ofType: null,
-              },
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'defaultValue',
-            description:
-              'A GraphQL-formatted string representing the default value for this input value.',
-            args: [],
-            type: {
-              kind: 'SCALAR',
-              name: 'String',
-              ofType: null,
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'isDeprecated',
-            description: null,
-            args: [],
-            type: {
-              kind: 'NON_NULL',
-              name: null,
-              ofType: {
-                kind: 'SCALAR',
-                name: 'Boolean',
-                ofType: null,
-              },
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'deprecationReason',
-            description: null,
-            args: [],
-            type: {
-              kind: 'SCALAR',
-              name: 'String',
-              ofType: null,
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-        ],
-        inputFields: null,
-        interfaces: [],
-        enumValues: null,
-        possibleTypes: null,
-      },
-      {
-        kind: 'OBJECT',
-        name: '__EnumValue',
-        description:
-          'One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.',
-        fields: [
-          {
-            name: 'name',
-            description: null,
-            args: [],
-            type: {
-              kind: 'NON_NULL',
-              name: null,
-              ofType: {
-                kind: 'SCALAR',
-                name: 'String',
-                ofType: null,
-              },
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'description',
-            description: null,
-            args: [],
-            type: {
-              kind: 'SCALAR',
-              name: 'String',
-              ofType: null,
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'isDeprecated',
-            description: null,
-            args: [],
-            type: {
-              kind: 'NON_NULL',
-              name: null,
-              ofType: {
-                kind: 'SCALAR',
-                name: 'Boolean',
-                ofType: null,
-              },
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'deprecationReason',
-            description: null,
-            args: [],
-            type: {
-              kind: 'SCALAR',
-              name: 'String',
-              ofType: null,
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-        ],
-        inputFields: null,
-        interfaces: [],
-        enumValues: null,
-        possibleTypes: null,
-      },
-      {
-        kind: 'OBJECT',
-        name: '__Directive',
-        description:
-          "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
-        fields: [
-          {
-            name: 'name',
-            description: null,
-            args: [],
-            type: {
-              kind: 'NON_NULL',
-              name: null,
-              ofType: {
-                kind: 'SCALAR',
-                name: 'String',
-                ofType: null,
-              },
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'description',
-            description: null,
-            args: [],
-            type: {
-              kind: 'SCALAR',
-              name: 'String',
-              ofType: null,
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'isRepeatable',
-            description: null,
-            args: [],
-            type: {
-              kind: 'NON_NULL',
-              name: null,
-              ofType: {
-                kind: 'SCALAR',
-                name: 'Boolean',
-                ofType: null,
-              },
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'locations',
-            description: null,
-            args: [],
-            type: {
-              kind: 'NON_NULL',
-              name: null,
-              ofType: {
-                kind: 'LIST',
-                name: null,
-                ofType: {
-                  kind: 'NON_NULL',
-                  name: null,
-                  ofType: {
-                    kind: 'ENUM',
-                    name: '__DirectiveLocation',
-                    ofType: null,
-                  },
-                },
-              },
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'args',
-            description: null,
-            args: [],
-            type: {
-              kind: 'NON_NULL',
-              name: null,
-              ofType: {
-                kind: 'LIST',
-                name: null,
-                ofType: {
-                  kind: 'NON_NULL',
-                  name: null,
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: '__InputValue',
-                    ofType: null,
-                  },
-                },
-              },
-            },
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-        ],
-        inputFields: null,
-        interfaces: [],
-        enumValues: null,
-        possibleTypes: null,
-      },
-      {
-        kind: 'ENUM',
-        name: '__DirectiveLocation',
-        description:
-          'A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.',
-        fields: null,
-        inputFields: null,
-        interfaces: null,
-        enumValues: [
-          {
-            name: 'QUERY',
-            description: 'Location adjacent to a query operation.',
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'MUTATION',
-            description: 'Location adjacent to a mutation operation.',
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'SUBSCRIPTION',
-            description: 'Location adjacent to a subscription operation.',
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'FIELD',
-            description: 'Location adjacent to a field.',
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'FRAGMENT_DEFINITION',
-            description: 'Location adjacent to a fragment definition.',
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'FRAGMENT_SPREAD',
-            description: 'Location adjacent to a fragment spread.',
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'INLINE_FRAGMENT',
-            description: 'Location adjacent to an inline fragment.',
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'VARIABLE_DEFINITION',
-            description: 'Location adjacent to a variable definition.',
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'SCHEMA',
-            description: 'Location adjacent to a schema definition.',
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'SCALAR',
-            description: 'Location adjacent to a scalar definition.',
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'OBJECT',
-            description: 'Location adjacent to an object type definition.',
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'FIELD_DEFINITION',
-            description: 'Location adjacent to a field definition.',
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'ARGUMENT_DEFINITION',
-            description: 'Location adjacent to an argument definition.',
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'INTERFACE',
-            description: 'Location adjacent to an interface definition.',
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'UNION',
-            description: 'Location adjacent to a union definition.',
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'ENUM',
-            description: 'Location adjacent to an enum definition.',
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'ENUM_VALUE',
-            description: 'Location adjacent to an enum value definition.',
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'INPUT_OBJECT',
-            description:
-              'Location adjacent to an input object type definition.',
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-          {
-            name: 'INPUT_FIELD_DEFINITION',
-            description:
-              'Location adjacent to an input object field definition.',
-            isDeprecated: false,
-            deprecationReason: null,
-          },
-        ],
-        possibleTypes: null,
+        kind: 'SCALAR',
+        name: 'Any',
       },
     ],
-    directives: [
-      {
-        name: 'include',
-        description:
-          'Directs the executor to include this field or fragment only when the `if` argument is true.',
-        locations: ['FIELD', 'FRAGMENT_SPREAD', 'INLINE_FRAGMENT'],
-        args: [
-          {
-            name: 'if',
-            description: 'Included when true.',
-            type: {
-              kind: 'NON_NULL',
-              name: null,
-              ofType: {
-                kind: 'SCALAR',
-                name: 'Boolean',
-                ofType: null,
-              },
-            },
-            defaultValue: null,
-          },
-        ],
-      },
-      {
-        name: 'skip',
-        description:
-          'Directs the executor to skip this field or fragment when the `if` argument is true.',
-        locations: ['FIELD', 'FRAGMENT_SPREAD', 'INLINE_FRAGMENT'],
-        args: [
-          {
-            name: 'if',
-            description: 'Skipped when true.',
-            type: {
-              kind: 'NON_NULL',
-              name: null,
-              ofType: {
-                kind: 'SCALAR',
-                name: 'Boolean',
-                ofType: null,
-              },
-            },
-            defaultValue: null,
-          },
-        ],
-      },
-      {
-        name: 'deprecated',
-        description:
-          'Marks an element of a GraphQL schema as no longer supported.',
-        locations: [
-          'FIELD_DEFINITION',
-          'ARGUMENT_DEFINITION',
-          'INPUT_FIELD_DEFINITION',
-          'ENUM_VALUE',
-        ],
-        args: [
-          {
-            name: 'reason',
-            description:
-              'Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax, as specified by [CommonMark](https://commonmark.org/).',
-            type: {
-              kind: 'SCALAR',
-              name: 'String',
-              ofType: null,
-            },
-            defaultValue: '"No longer supported"',
-          },
-        ],
-      },
-      {
-        name: 'specifiedBy',
-        description:
-          'Exposes a URL that specifies the behaviour of this scalar.',
-        locations: ['SCALAR'],
-        args: [
-          {
-            name: 'url',
-            description: 'The URL that specifies the behaviour of this scalar.',
-            type: {
-              kind: 'NON_NULL',
-              name: null,
-              ofType: {
-                kind: 'SCALAR',
-                name: 'String',
-                ofType: null,
-              },
-            },
-            defaultValue: null,
-          },
-        ],
-      },
-    ],
+    directives: [],
   },
 } as const;
+
+export { introspection };

--- a/packages/example-tada/tsconfig.json
+++ b/packages/example-tada/tsconfig.json
@@ -7,7 +7,7 @@
         "disableTypegen": true,
         "shouldCheckForColocatedFragments": true,
         "trackFieldUsage": true,
-        "tadaOutputLocation": "."
+        "tadaOutputLocation": "./introspection.ts"
       }
     ],
     "jsx": "react-jsx",

--- a/packages/graphqlsp/package.json
+++ b/packages/graphqlsp/package.json
@@ -44,12 +44,13 @@
     "*.{js,ts,json,md}": "prettier --write"
   },
   "devDependencies": {
+    "@sindresorhus/fnv1a": "^2.0.0",
     "@types/node": "^18.15.11",
     "@types/node-fetch": "^2.6.3",
-    "@sindresorhus/fnv1a": "^2.0.0",
-    "lru-cache": "^10.0.1",
-    "graphql-language-service": "^5.2.0",
+    "@urql/introspection": "^1.0.2",
     "graphql": "^16.8.1",
+    "graphql-language-service": "^5.2.0",
+    "lru-cache": "^10.0.1",
     "typescript": "^5.3.3"
   },
   "dependencies": {

--- a/packages/graphqlsp/src/graphql/getSchema.ts
+++ b/packages/graphqlsp/src/graphql/getSchema.ts
@@ -36,7 +36,7 @@ const tsAnnotationComment = [
   ' * @example',
   ' * ```',
   " * import { initGraphQLTada } from 'gql.tada';",
-  " * import { introspection } from './introspection';",
+  " * import type { introspection } from './introspection';",
   ' *',
   ' * export const graphql = initGraphQLTada<{',
   ' *   introspection: typeof introspection;',

--- a/packages/graphqlsp/src/graphql/getSchema.ts
+++ b/packages/graphqlsp/src/graphql/getSchema.ts
@@ -68,10 +68,10 @@ async function saveTadaIntrospection(
 
   const json = JSON.stringify(minified, null, 2);
 
-  let contents = `const introspection = ${json} as const;`;
   let output = path.resolve(path.dirname(root), tadaOutputLocation);
-
   let stat: fs.Stats;
+  let contents = '';
+
   try {
     stat = await fs.promises.stat(output);
   } catch (error) {
@@ -79,7 +79,6 @@ async function saveTadaIntrospection(
     return;
   }
 
-  let fileContents = '';
   if (stat.isDirectory()) {
     output = path.join(output, 'introspection.d.ts');
   } else if (!stat.isFile()) {
@@ -91,7 +90,8 @@ async function saveTadaIntrospection(
     contents = [
       dtsAnnotationComment,
       contents,
-      '\n',
+      `declare const introspection: ${json};\n`,
+      "import * as gqlTada from 'gql.tada';\n",
       "declare module 'gql.tada' {",
       '  interface setupSchema {',
       '    introspection: typeof introspection',
@@ -101,7 +101,7 @@ async function saveTadaIntrospection(
   } else if (path.extname(output) === '.ts') {
     contents = [
       tsAnnotationComment,
-      contents,
+      `const introspection = ${json} as const;\n`,
       'export { introspection };',
     ].join('\n');
   } else {

--- a/packages/graphqlsp/src/graphql/getSchema.ts
+++ b/packages/graphqlsp/src/graphql/getSchema.ts
@@ -99,7 +99,6 @@ async function saveTadaIntrospection(
   if (/\.d\.ts$/.test(output)) {
     contents = [
       dtsAnnotationComment,
-      contents,
       `declare const introspection: ${json};\n`,
       "import * as gqlTada from 'gql.tada';\n",
       "declare module 'gql.tada' {",

--- a/packages/graphqlsp/src/graphql/getSchema.ts
+++ b/packages/graphqlsp/src/graphql/getSchema.ts
@@ -6,6 +6,8 @@ import {
   IntrospectionQuery,
   introspectionFromSchema,
 } from 'graphql';
+
+import { minifyIntrospectionQuery } from '@urql/introspection';
 import fetch from 'node-fetch';
 import path from 'path';
 import fs from 'fs';
@@ -21,7 +23,14 @@ async function saveTadaIntrospection(
     ? introspectionFromSchema(schema, { descriptions: false })
     : schema;
 
-  const json = JSON.stringify(introspection, null, 2);
+  const minified = minifyIntrospectionQuery(introspection, {
+    includeDirectives: false,
+    includeEnums: true,
+    includeInputs: true,
+    includeScalars: true,
+  });
+
+  const json = JSON.stringify(minified, null, 2);
   const contents = `export const introspection = ${json} as const;`;
 
   await fs.promises.writeFile(

--- a/packages/graphqlsp/src/graphql/getSchema.ts
+++ b/packages/graphqlsp/src/graphql/getSchema.ts
@@ -69,17 +69,27 @@ async function saveTadaIntrospection(
   const json = JSON.stringify(minified, null, 2);
 
   let output = path.resolve(path.dirname(root), tadaOutputLocation);
-  let stat: fs.Stats;
+  let stat: fs.Stats | undefined;
   let contents = '';
 
   try {
     stat = await fs.promises.stat(output);
   } catch (error) {
     logger(`Failed to resolve path @ ${output}`);
-    return;
   }
 
-  if (stat.isDirectory()) {
+  if (!stat) {
+    try {
+      stat = await fs.promises.stat(path.dirname(output));
+      if (!stat.isDirectory()) {
+        logger(`Output file is not inside a directory @ ${output}`);
+        return;
+      }
+    } catch (error) {
+      logger(`Directory does not exist @ ${output}`);
+      return;
+    }
+  } else if (stat.isDirectory()) {
     output = path.join(output, 'introspection.d.ts');
   } else if (!stat.isFile()) {
     logger(`No file or directory found on path @ ${output}`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,9 @@ importers:
       '@types/node-fetch':
         specifier: ^2.6.3
         version: 2.6.3
+      '@urql/introspection':
+        specifier: ^1.0.2
+        version: 1.0.2(graphql@16.8.1)
       graphql:
         specifier: ^16.8.1
         version: 16.8.1
@@ -2345,6 +2348,14 @@ packages:
     transitivePeerDependencies:
       - graphql
     dev: false
+
+  /@urql/introspection@1.0.2(graphql@16.8.1):
+    resolution: {integrity: sha512-vPuX+DjbmL5EUsvwgAMV8dkxc7JKuuNTzDfsNvtCuVmbAED4Nx39p08HImjTWAewSatjyzZZs+fAhU7z/4P+UQ==}
+    peerDependencies:
+      graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      graphql: 16.8.1
+    dev: true
 
   /@vitest/expect@0.34.6:
     resolution: {integrity: sha512-QUzKpUQRc1qC7qdGo7rMK3AkETI7w18gTCUrsNnyjjJKYiuUB9+TQK3QnR1unhCnWRC0AbKv2omLGQDF/mIjOw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,10 +19,10 @@ importers:
     devDependencies:
       '@babel/plugin-transform-block-scoping':
         specifier: ^7.23.4
-        version: 7.23.4(@babel/core@7.23.3)
+        version: 7.23.4(@babel/core@7.23.7)
       '@babel/plugin-transform-typescript':
         specifier: ^7.23.6
-        version: 7.23.6(@babel/core@7.23.3)
+        version: 7.23.6(@babel/core@7.23.7)
       '@changesets/cli':
         specifier: ^2.26.2
         version: 2.26.2
@@ -31,7 +31,7 @@ importers:
         version: 0.5.2
       '@rollup/plugin-babel':
         specifier: ^6.0.4
-        version: 6.0.4(@babel/core@7.23.3)(rollup@4.9.5)
+        version: 6.0.4(@babel/core@7.23.7)(rollup@4.9.5)
       '@rollup/plugin-commonjs':
         specifier: ^25.0.7
         version: 25.0.7(rollup@4.9.5)
@@ -138,7 +138,7 @@ importers:
         version: 3.2.2(graphql@16.8.1)
       gql.tada:
         specifier: '*'
-        version: 1.0.0-beta.1(graphql@16.8.1)
+        version: 1.0.0-beta.2(graphql@16.8.1)
       graphql:
         specifier: ^16.8.1
         version: 16.8.1
@@ -266,12 +266,12 @@ packages:
       graphql: 16.8.1
     dev: false
 
-  /@ampproject/remapping@2.2.0:
-    resolution: {integrity: sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==}
+  /@ampproject/remapping@2.2.1:
+    resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      '@jridgewell/gen-mapping': 0.1.1
-      '@jridgewell/trace-mapping': 0.3.20
+      '@jridgewell/gen-mapping': 0.3.3
+      '@jridgewell/trace-mapping': 0.3.21
     dev: true
 
   /@ardatan/relay-compiler@12.0.0(graphql@16.8.1):
@@ -280,13 +280,13 @@ packages:
     peerDependencies:
       graphql: '*'
     dependencies:
-      '@babel/core': 7.23.3
-      '@babel/generator': 7.23.4
-      '@babel/parser': 7.23.4
+      '@babel/core': 7.23.7
+      '@babel/generator': 7.23.6
+      '@babel/parser': 7.23.6
       '@babel/runtime': 7.20.6
-      '@babel/traverse': 7.23.4
-      '@babel/types': 7.23.4
-      babel-preset-fbjs: 3.4.0(@babel/core@7.23.3)
+      '@babel/traverse': 7.23.7
+      '@babel/types': 7.23.6
+      babel-preset-fbjs: 3.4.0(@babel/core@7.23.7)
       chalk: 4.1.2
       fb-watchman: 2.0.2
       fbjs: 3.0.4
@@ -312,33 +312,33 @@ packages:
       - encoding
     dev: true
 
-  /@babel/code-frame@7.23.4:
-    resolution: {integrity: sha512-r1IONyb6Ia+jYR2vvIDhdWdlTGhqbBoFqLTQidzZ4kepUFH15ejXvFHxCVbtl7BOXIudsIubf4E81xeA3h3IXA==}
+  /@babel/code-frame@7.23.5:
+    resolution: {integrity: sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/highlight': 7.23.4
       chalk: 2.4.2
     dev: true
 
-  /@babel/compat-data@7.23.3:
-    resolution: {integrity: sha512-BmR4bWbDIoFJmJ9z2cZ8Gmm2MXgEDgjdWgpKmKWUt54UGFJdlj31ECtbaDvCG/qVdG3AQ1SfpZEs01lUFbzLOQ==}
+  /@babel/compat-data@7.23.5:
+    resolution: {integrity: sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==}
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/core@7.23.3:
-    resolution: {integrity: sha512-Jg+msLuNuCJDyBvFv5+OKOUjWMZgd85bKjbICd3zWrKAo+bJ49HJufi7CQE0q0uR8NGyO6xkCACScNqyjHSZew==}
+  /@babel/core@7.23.7:
+    resolution: {integrity: sha512-+UpDgowcmqe36d4NwqvKsyPMlOLNGMsfMmQ5WGCu+siCe3t3dfe9njrzGfdN4qq+bcNUt0+Vw6haRxBOycs4dw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@ampproject/remapping': 2.2.0
-      '@babel/code-frame': 7.23.4
-      '@babel/generator': 7.23.4
-      '@babel/helper-compilation-targets': 7.22.15
-      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.3)
-      '@babel/helpers': 7.23.4
-      '@babel/parser': 7.23.4
+      '@ampproject/remapping': 2.2.1
+      '@babel/code-frame': 7.23.5
+      '@babel/generator': 7.23.6
+      '@babel/helper-compilation-targets': 7.23.6
+      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.7)
+      '@babel/helpers': 7.23.8
+      '@babel/parser': 7.23.6
       '@babel/template': 7.22.15
-      '@babel/traverse': 7.23.4
-      '@babel/types': 7.23.4
+      '@babel/traverse': 7.23.7
+      '@babel/types': 7.23.6
       convert-source-map: 2.0.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
@@ -348,13 +348,13 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/generator@7.23.4:
-    resolution: {integrity: sha512-esuS49Cga3HcThFNebGhlgsrVLkvhqvYDTzgjfFFlHJcIfLe5jFmRRfCQ1KuBfc4Jrtn3ndLgKWAKjBE+IraYQ==}
+  /@babel/generator@7.23.6:
+    resolution: {integrity: sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.4
-      '@jridgewell/gen-mapping': 0.3.2
-      '@jridgewell/trace-mapping': 0.3.20
+      '@babel/types': 7.23.6
+      '@jridgewell/gen-mapping': 0.3.3
+      '@jridgewell/trace-mapping': 0.3.21
       jsesc: 2.5.2
     dev: true
 
@@ -362,33 +362,33 @@ packages:
     resolution: {integrity: sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.4
+      '@babel/types': 7.23.6
     dev: true
 
-  /@babel/helper-compilation-targets@7.22.15:
-    resolution: {integrity: sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==}
+  /@babel/helper-compilation-targets@7.23.6:
+    resolution: {integrity: sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/compat-data': 7.23.3
-      '@babel/helper-validator-option': 7.22.15
-      browserslist: 4.22.1
+      '@babel/compat-data': 7.23.5
+      '@babel/helper-validator-option': 7.23.5
+      browserslist: 4.22.2
       lru-cache: 5.1.1
       semver: 6.3.1
     dev: true
 
-  /@babel/helper-create-class-features-plugin@7.23.7(@babel/core@7.23.3):
+  /@babel/helper-create-class-features-plugin@7.23.7(@babel/core@7.23.7):
     resolution: {integrity: sha512-xCoqR/8+BoNnXOY7RVSgv6X+o7pmT5q1d+gGcRlXYkI+9B31glE4jeejhKVpA04O1AtzOt7OSQ6VYKP5FcRl9g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.7
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-member-expression-to-functions': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
-      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.3)
+      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.7)
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       semver: 6.3.1
@@ -404,37 +404,37 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.22.15
-      '@babel/types': 7.23.4
+      '@babel/types': 7.23.6
     dev: true
 
   /@babel/helper-hoist-variables@7.22.5:
     resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.4
+      '@babel/types': 7.23.6
     dev: true
 
   /@babel/helper-member-expression-to-functions@7.23.0:
     resolution: {integrity: sha512-6gfrPwh7OuT6gZyJZvd6WbTfrqAo7vm4xCzAXOusKqq/vWdKXphTpj5klHKNmRUU6/QRGlBsyU9mAIPaWHlqJA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.4
+      '@babel/types': 7.23.6
     dev: true
 
   /@babel/helper-module-imports@7.22.15:
     resolution: {integrity: sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.4
+      '@babel/types': 7.23.6
     dev: true
 
-  /@babel/helper-module-transforms@7.23.3(@babel/core@7.23.3):
+  /@babel/helper-module-transforms@7.23.3(@babel/core@7.23.7):
     resolution: {integrity: sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.7
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-simple-access': 7.22.5
@@ -446,7 +446,7 @@ packages:
     resolution: {integrity: sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.4
+      '@babel/types': 7.23.6
     dev: true
 
   /@babel/helper-plugin-utils@7.22.5:
@@ -454,13 +454,13 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/helper-replace-supers@7.22.20(@babel/core@7.23.3):
+  /@babel/helper-replace-supers@7.22.20(@babel/core@7.23.7):
     resolution: {integrity: sha512-qsW0In3dbwQUbK8kejJ4R7IHVGwHJlV6lpG6UA7a9hSa2YEiAib+N1T2kr6PEeUT+Fl7najmSOS6SmAwCHK6Tw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.7
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-member-expression-to-functions': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
@@ -470,21 +470,21 @@ packages:
     resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.4
+      '@babel/types': 7.23.6
     dev: true
 
   /@babel/helper-skip-transparent-expression-wrappers@7.22.5:
     resolution: {integrity: sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.4
+      '@babel/types': 7.23.6
     dev: true
 
   /@babel/helper-split-export-declaration@7.22.6:
     resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.4
+      '@babel/types': 7.23.6
     dev: true
 
   /@babel/helper-string-parser@7.23.4:
@@ -497,18 +497,18 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/helper-validator-option@7.22.15:
-    resolution: {integrity: sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==}
+  /@babel/helper-validator-option@7.23.5:
+    resolution: {integrity: sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==}
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/helpers@7.23.4:
-    resolution: {integrity: sha512-HfcMizYz10cr3h29VqyfGL6ZWIjTwWfvYBMsBVGwpcbhNGe3wQ1ZXZRPzZoAHhd9OqHadHqjQ89iVKINXnbzuw==}
+  /@babel/helpers@7.23.8:
+    resolution: {integrity: sha512-KDqYz4PiOWvDFrdHLPhKtCThtIcKVy6avWD2oG4GEvyQ+XDZwHD4YQd+H2vNMnq2rkdxsDkU82T+Vk8U/WXHRQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.22.15
-      '@babel/traverse': 7.23.4
-      '@babel/types': 7.23.4
+      '@babel/traverse': 7.23.7
+      '@babel/types': 7.23.6
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -522,329 +522,329 @@ packages:
       js-tokens: 4.0.0
     dev: true
 
-  /@babel/parser@7.23.4:
-    resolution: {integrity: sha512-vf3Xna6UEprW+7t6EtOmFpHNAuxw3xqPZghy+brsnusscJRW5BMUzzHZc5ICjULee81WeUV2jjakG09MDglJXQ==}
+  /@babel/parser@7.23.6:
+    resolution: {integrity: sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.23.4
+      '@babel/types': 7.23.6
     dev: true
 
-  /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.23.3):
+  /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.23.7):
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
     engines: {node: '>=6.9.0'}
     deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-create-class-features-plugin': 7.23.7(@babel/core@7.23.3)
+      '@babel/core': 7.23.7
+      '@babel/helper-create-class-features-plugin': 7.23.7(@babel/core@7.23.7)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-proposal-object-rest-spread@7.20.2(@babel/core@7.23.3):
+  /@babel/plugin-proposal-object-rest-spread@7.20.2(@babel/core@7.23.7):
     resolution: {integrity: sha512-Ks6uej9WFK+fvIMesSqbAto5dD8Dz4VuuFvGJFKgIGSkJuRGcrwGECPA1fDgQK3/DbExBJpEkTeYeB8geIFCSQ==}
     engines: {node: '>=6.9.0'}
     deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.23.3
-      '@babel/core': 7.23.3
-      '@babel/helper-compilation-targets': 7.22.15
+      '@babel/compat-data': 7.23.5
+      '@babel/core': 7.23.7
+      '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.3)
-      '@babel/plugin-transform-parameters': 7.20.5(@babel/core@7.23.3)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-parameters': 7.20.5(@babel/core@7.23.7)
     dev: true
 
-  /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.23.3):
+  /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.23.7):
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-syntax-flow@7.18.6(@babel/core@7.23.3):
+  /@babel/plugin-syntax-flow@7.18.6(@babel/core@7.23.7):
     resolution: {integrity: sha512-LUbR+KNTBWCUAqRG9ex5Gnzu2IOkt8jRJbHHXFT9q+L9zm7M/QQbEqXyw1n1pohYvOyWC8CjeyjrSaIwiYjK7A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-syntax-import-assertions@7.23.3(@babel/core@7.23.3):
+  /@babel/plugin-syntax-import-assertions@7.23.3(@babel/core@7.23.7):
     resolution: {integrity: sha512-lPgDSU+SJLK3xmFDTV2ZRQAiM7UuUjGidwBywFavObCiZc1BeAAcMtHJKUya92hPHO+at63JJPLygilZard8jw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-syntax-jsx@7.18.6(@babel/core@7.23.3):
+  /@babel/plugin-syntax-jsx@7.18.6(@babel/core@7.23.7):
     resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.23.3):
+  /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.23.7):
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-syntax-typescript@7.23.3(@babel/core@7.23.3):
+  /@babel/plugin-syntax-typescript@7.23.3(@babel/core@7.23.7):
     resolution: {integrity: sha512-9EiNjVJOMwCO+43TqoTrgQ8jMwcAd0sWyXi9RPfIsLTj4R2MADDDQXELhffaUx/uJv2AYcxBgPwH6j4TIA4ytQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-arrow-functions@7.18.6(@babel/core@7.23.3):
+  /@babel/plugin-transform-arrow-functions@7.18.6(@babel/core@7.23.7):
     resolution: {integrity: sha512-9S9X9RUefzrsHZmKMbDXxweEH+YlE8JJEuat9FdvW9Qh1cw7W64jELCtWNkPBPX5En45uy28KGvA/AySqUh8CQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-block-scoped-functions@7.18.6(@babel/core@7.23.3):
+  /@babel/plugin-transform-block-scoped-functions@7.18.6(@babel/core@7.23.7):
     resolution: {integrity: sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-block-scoping@7.23.4(@babel/core@7.23.3):
+  /@babel/plugin-transform-block-scoping@7.23.4(@babel/core@7.23.7):
     resolution: {integrity: sha512-0QqbP6B6HOh7/8iNR4CQU2Th/bbRtBp4KS9vcaZd1fZ0wSh5Fyssg0UCIHwxh+ka+pNDREbVLQnHCMHKZfPwfw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-classes@7.20.2(@babel/core@7.23.3):
+  /@babel/plugin-transform-classes@7.20.2(@babel/core@7.23.7):
     resolution: {integrity: sha512-9rbPp0lCVVoagvtEyQKSo5L8oo0nQS/iif+lwlAz29MccX2642vWDlSZK+2T2buxbopotId2ld7zZAzRfz9j1g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.7
       '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-compilation-targets': 7.22.15
+      '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.3)
+      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.7)
       '@babel/helper-split-export-declaration': 7.22.6
       globals: 11.12.0
     dev: true
 
-  /@babel/plugin-transform-computed-properties@7.18.9(@babel/core@7.23.3):
+  /@babel/plugin-transform-computed-properties@7.18.9(@babel/core@7.23.7):
     resolution: {integrity: sha512-+i0ZU1bCDymKakLxn5srGHrsAPRELC2WIbzwjLhHW9SIE1cPYkLCL0NlnXMZaM1vhfgA2+M7hySk42VBvrkBRw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-destructuring@7.20.2(@babel/core@7.23.3):
+  /@babel/plugin-transform-destructuring@7.20.2(@babel/core@7.23.7):
     resolution: {integrity: sha512-mENM+ZHrvEgxLTBXUiQ621rRXZes3KWUv6NdQlrnr1TkWVw+hUjQBZuP2X32qKlrlG2BzgR95gkuCRSkJl8vIw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-flow-strip-types@7.19.0(@babel/core@7.23.3):
+  /@babel/plugin-transform-flow-strip-types@7.19.0(@babel/core@7.23.7):
     resolution: {integrity: sha512-sgeMlNaQVbCSpgLSKP4ZZKfsJVnFnNQlUSk6gPYzR/q7tzCgQF2t8RBKAP6cKJeZdveei7Q7Jm527xepI8lNLg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-flow': 7.18.6(@babel/core@7.23.3)
+      '@babel/plugin-syntax-flow': 7.18.6(@babel/core@7.23.7)
     dev: true
 
-  /@babel/plugin-transform-for-of@7.18.8(@babel/core@7.23.3):
+  /@babel/plugin-transform-for-of@7.18.8(@babel/core@7.23.7):
     resolution: {integrity: sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-function-name@7.18.9(@babel/core@7.23.3):
+  /@babel/plugin-transform-function-name@7.18.9(@babel/core@7.23.7):
     resolution: {integrity: sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-compilation-targets': 7.22.15
+      '@babel/core': 7.23.7
+      '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-literals@7.18.9(@babel/core@7.23.3):
+  /@babel/plugin-transform-literals@7.18.9(@babel/core@7.23.7):
     resolution: {integrity: sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-member-expression-literals@7.18.6(@babel/core@7.23.3):
+  /@babel/plugin-transform-member-expression-literals@7.18.6(@babel/core@7.23.7):
     resolution: {integrity: sha512-qSF1ihLGO3q+/g48k85tUjD033C29TNTVB2paCwZPVmOsjn9pClvYYrM2VeJpBY2bcNkuny0YUyTNRyRxJ54KA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-modules-commonjs@7.19.6(@babel/core@7.23.3):
+  /@babel/plugin-transform-modules-commonjs@7.19.6(@babel/core@7.23.7):
     resolution: {integrity: sha512-8PIa1ym4XRTKuSsOUXqDG0YaOlEuTVvHMe5JCfgBMOtHvJKw/4NGovEGN33viISshG/rZNVrACiBmPQLvWN8xQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.3)
+      '@babel/core': 7.23.7
+      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.7)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-simple-access': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-object-super@7.18.6(@babel/core@7.23.3):
+  /@babel/plugin-transform-object-super@7.18.6(@babel/core@7.23.7):
     resolution: {integrity: sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.3)
+      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.7)
     dev: true
 
-  /@babel/plugin-transform-parameters@7.20.5(@babel/core@7.23.3):
+  /@babel/plugin-transform-parameters@7.20.5(@babel/core@7.23.7):
     resolution: {integrity: sha512-h7plkOmcndIUWXZFLgpbrh2+fXAi47zcUX7IrOQuZdLD0I0KvjJ6cvo3BEcAOsDOcZhVKGJqv07mkSqK0y2isQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-property-literals@7.18.6(@babel/core@7.23.3):
+  /@babel/plugin-transform-property-literals@7.18.6(@babel/core@7.23.7):
     resolution: {integrity: sha512-cYcs6qlgafTud3PAzrrRNbQtfpQ8+y/+M5tKmksS9+M1ckbH6kzY8MrexEM9mcA6JDsukE19iIRvAyYl463sMg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-react-display-name@7.18.6(@babel/core@7.23.3):
+  /@babel/plugin-transform-react-display-name@7.18.6(@babel/core@7.23.7):
     resolution: {integrity: sha512-TV4sQ+T013n61uMoygyMRm+xf04Bd5oqFpv2jAEQwSZ8NwQA7zeRPg1LMVg2PWi3zWBz+CLKD+v5bcpZ/BS0aA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-react-jsx@7.19.0(@babel/core@7.23.3):
+  /@babel/plugin-transform-react-jsx@7.19.0(@babel/core@7.23.7):
     resolution: {integrity: sha512-UVEvX3tXie3Szm3emi1+G63jyw1w5IcMY0FSKM+CRnKRI5Mr1YbCNgsSTwoTwKphQEG9P+QqmuRFneJPZuHNhg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.7
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.23.3)
-      '@babel/types': 7.23.4
+      '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.23.7)
+      '@babel/types': 7.23.6
     dev: true
 
-  /@babel/plugin-transform-shorthand-properties@7.18.6(@babel/core@7.23.3):
+  /@babel/plugin-transform-shorthand-properties@7.18.6(@babel/core@7.23.7):
     resolution: {integrity: sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-spread@7.19.0(@babel/core@7.23.3):
+  /@babel/plugin-transform-spread@7.19.0(@babel/core@7.23.7):
     resolution: {integrity: sha512-RsuMk7j6n+r752EtzyScnWkQyuJdli6LdO5Klv8Yx0OfPVTcQkIUfS8clx5e9yHXzlnhOZF3CbQ8C2uP5j074w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-template-literals@7.18.9(@babel/core@7.23.3):
+  /@babel/plugin-transform-template-literals@7.18.9(@babel/core@7.23.7):
     resolution: {integrity: sha512-S8cOWfT82gTezpYOiVaGHrCbhlHgKhQt8XH5ES46P2XWmX92yisoZywf5km75wv5sYcXDUCLMmMxOLCtthDgMA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-typescript@7.23.6(@babel/core@7.23.3):
+  /@babel/plugin-transform-typescript@7.23.6(@babel/core@7.23.7):
     resolution: {integrity: sha512-6cBG5mBvUu4VUD04OHKnYzbuHNP8huDsD3EDqqpIpsswTDoqHCjLoHb6+QgsV1WsT2nipRqCPgxD3LXnEO7XfA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.7
       '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.23.7(@babel/core@7.23.3)
+      '@babel/helper-create-class-features-plugin': 7.23.7(@babel/core@7.23.7)
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-typescript': 7.23.3(@babel/core@7.23.3)
+      '@babel/plugin-syntax-typescript': 7.23.3(@babel/core@7.23.7)
     dev: true
 
   /@babel/runtime@7.20.6:
@@ -858,31 +858,31 @@ packages:
     resolution: {integrity: sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.23.4
-      '@babel/parser': 7.23.4
-      '@babel/types': 7.23.4
+      '@babel/code-frame': 7.23.5
+      '@babel/parser': 7.23.6
+      '@babel/types': 7.23.6
     dev: true
 
-  /@babel/traverse@7.23.4:
-    resolution: {integrity: sha512-IYM8wSUwunWTB6tFC2dkKZhxbIjHoWemdK+3f8/wq8aKhbUscxD5MX72ubd90fxvFknaLPeGw5ycU84V1obHJg==}
+  /@babel/traverse@7.23.7:
+    resolution: {integrity: sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.23.4
-      '@babel/generator': 7.23.4
+      '@babel/code-frame': 7.23.5
+      '@babel/generator': 7.23.6
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/parser': 7.23.4
-      '@babel/types': 7.23.4
+      '@babel/parser': 7.23.6
+      '@babel/types': 7.23.6
       debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/types@7.23.4:
-    resolution: {integrity: sha512-7uIFwVYpoplT5jp/kVv6EF93VaJ8H+Yn5IczYiaAi98ajzjfoZfslet/e0sLh+wVBjb2qqIut1b0S26VSafsSQ==}
+  /@babel/types@7.23.6:
+    resolution: {integrity: sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': 7.23.4
@@ -1308,9 +1308,9 @@ packages:
       '@parcel/watcher':
         optional: true
     dependencies:
-      '@babel/generator': 7.23.4
+      '@babel/generator': 7.23.6
       '@babel/template': 7.22.15
-      '@babel/types': 7.23.4
+      '@babel/types': 7.23.6
       '@graphql-codegen/core': 4.0.0(graphql@16.8.1)
       '@graphql-codegen/plugin-helpers': 5.0.1(graphql@16.8.1)
       '@graphql-tools/apollo-engine-loader': 8.0.0(graphql@16.8.1)
@@ -1694,11 +1694,11 @@ packages:
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@babel/core': 7.23.3
-      '@babel/parser': 7.23.4
-      '@babel/plugin-syntax-import-assertions': 7.23.3(@babel/core@7.23.3)
-      '@babel/traverse': 7.23.4
-      '@babel/types': 7.23.4
+      '@babel/core': 7.23.7
+      '@babel/parser': 7.23.6
+      '@babel/plugin-syntax-import-assertions': 7.23.3(@babel/core@7.23.7)
+      '@babel/traverse': 7.23.7
+      '@babel/types': 7.23.6
       '@graphql-tools/utils': 10.0.11(graphql@16.8.1)
       graphql: 16.8.1
       tslib: 2.6.2
@@ -1894,25 +1894,17 @@ packages:
       '@sinclair/typebox': 0.27.8
     dev: true
 
-  /@jridgewell/gen-mapping@0.1.1:
-    resolution: {integrity: sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==}
+  /@jridgewell/gen-mapping@0.3.3:
+    resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/trace-mapping': 0.3.21
     dev: true
 
-  /@jridgewell/gen-mapping@0.3.2:
-    resolution: {integrity: sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==}
-    engines: {node: '>=6.0.0'}
-    dependencies:
-      '@jridgewell/set-array': 1.1.2
-      '@jridgewell/sourcemap-codec': 1.4.15
-      '@jridgewell/trace-mapping': 0.3.20
-    dev: true
-
-  /@jridgewell/resolve-uri@3.1.0:
-    resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
+  /@jridgewell/resolve-uri@3.1.1:
+    resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
     engines: {node: '>=6.0.0'}
     dev: true
 
@@ -1924,25 +1916,25 @@ packages:
   /@jridgewell/source-map@0.3.3:
     resolution: {integrity: sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==}
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.2
-      '@jridgewell/trace-mapping': 0.3.20
+      '@jridgewell/gen-mapping': 0.3.3
+      '@jridgewell/trace-mapping': 0.3.21
     dev: true
 
   /@jridgewell/sourcemap-codec@1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
     dev: true
 
-  /@jridgewell/trace-mapping@0.3.20:
-    resolution: {integrity: sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==}
+  /@jridgewell/trace-mapping@0.3.21:
+    resolution: {integrity: sha512-SRfKmRe1KvYnxjEMtxEr+J4HIeMX5YBg/qhRHpxEIGjhX1rshcHlnFUE9K0GazhVKWM7B+nARSkV8LuvJdJ5/g==}
     dependencies:
-      '@jridgewell/resolve-uri': 3.1.0
+      '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
   /@jridgewell/trace-mapping@0.3.9:
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
     dependencies:
-      '@jridgewell/resolve-uri': 3.1.0
+      '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
@@ -2017,7 +2009,7 @@ packages:
     resolution: {integrity: sha512-l3YHBLAol6d/IKnB9LhpD0cEZWAoe3eFKUyTYWmFmCO2Q/WOckxLQAUyMZWwZV2M/m3+4vgRoaolFqaII82/TA==}
     dev: true
 
-  /@rollup/plugin-babel@6.0.4(@babel/core@7.23.3)(rollup@4.9.5):
+  /@rollup/plugin-babel@6.0.4(@babel/core@7.23.7)(rollup@4.9.5):
     resolution: {integrity: sha512-YF7Y52kFdFT/xVSuVdjkV5ZdX/3YtmX0QulG+x0taQOtJdHYzVU61aSSkAgVJ7NOv6qPkIYiJSgSWWN/DM5sGw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -2030,7 +2022,7 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.23.7
       '@babel/helper-module-imports': 7.22.15
       '@rollup/pluginutils': 5.1.0(rollup@4.9.5)
       rollup: 4.9.5
@@ -2605,38 +2597,38 @@ packages:
     resolution: {integrity: sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==}
     dev: true
 
-  /babel-preset-fbjs@3.4.0(@babel/core@7.23.3):
+  /babel-preset-fbjs@3.4.0(@babel/core@7.23.7):
     resolution: {integrity: sha512-9ywCsCvo1ojrw0b+XYk7aFvTH6D9064t0RIL1rtMf3nsa02Xw41MS7sZw216Im35xj/UY0PDBQsa1brUDDF1Ow==}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.23.3
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.23.3)
-      '@babel/plugin-proposal-object-rest-spread': 7.20.2(@babel/core@7.23.3)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.23.3)
-      '@babel/plugin-syntax-flow': 7.18.6(@babel/core@7.23.3)
-      '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.23.3)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.3)
-      '@babel/plugin-transform-arrow-functions': 7.18.6(@babel/core@7.23.3)
-      '@babel/plugin-transform-block-scoped-functions': 7.18.6(@babel/core@7.23.3)
-      '@babel/plugin-transform-block-scoping': 7.23.4(@babel/core@7.23.3)
-      '@babel/plugin-transform-classes': 7.20.2(@babel/core@7.23.3)
-      '@babel/plugin-transform-computed-properties': 7.18.9(@babel/core@7.23.3)
-      '@babel/plugin-transform-destructuring': 7.20.2(@babel/core@7.23.3)
-      '@babel/plugin-transform-flow-strip-types': 7.19.0(@babel/core@7.23.3)
-      '@babel/plugin-transform-for-of': 7.18.8(@babel/core@7.23.3)
-      '@babel/plugin-transform-function-name': 7.18.9(@babel/core@7.23.3)
-      '@babel/plugin-transform-literals': 7.18.9(@babel/core@7.23.3)
-      '@babel/plugin-transform-member-expression-literals': 7.18.6(@babel/core@7.23.3)
-      '@babel/plugin-transform-modules-commonjs': 7.19.6(@babel/core@7.23.3)
-      '@babel/plugin-transform-object-super': 7.18.6(@babel/core@7.23.3)
-      '@babel/plugin-transform-parameters': 7.20.5(@babel/core@7.23.3)
-      '@babel/plugin-transform-property-literals': 7.18.6(@babel/core@7.23.3)
-      '@babel/plugin-transform-react-display-name': 7.18.6(@babel/core@7.23.3)
-      '@babel/plugin-transform-react-jsx': 7.19.0(@babel/core@7.23.3)
-      '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.23.3)
-      '@babel/plugin-transform-spread': 7.19.0(@babel/core@7.23.3)
-      '@babel/plugin-transform-template-literals': 7.18.9(@babel/core@7.23.3)
+      '@babel/core': 7.23.7
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.23.7)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.2(@babel/core@7.23.7)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.23.7)
+      '@babel/plugin-syntax-flow': 7.18.6(@babel/core@7.23.7)
+      '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.23.7)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-arrow-functions': 7.18.6(@babel/core@7.23.7)
+      '@babel/plugin-transform-block-scoped-functions': 7.18.6(@babel/core@7.23.7)
+      '@babel/plugin-transform-block-scoping': 7.23.4(@babel/core@7.23.7)
+      '@babel/plugin-transform-classes': 7.20.2(@babel/core@7.23.7)
+      '@babel/plugin-transform-computed-properties': 7.18.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-destructuring': 7.20.2(@babel/core@7.23.7)
+      '@babel/plugin-transform-flow-strip-types': 7.19.0(@babel/core@7.23.7)
+      '@babel/plugin-transform-for-of': 7.18.8(@babel/core@7.23.7)
+      '@babel/plugin-transform-function-name': 7.18.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-literals': 7.18.9(@babel/core@7.23.7)
+      '@babel/plugin-transform-member-expression-literals': 7.18.6(@babel/core@7.23.7)
+      '@babel/plugin-transform-modules-commonjs': 7.19.6(@babel/core@7.23.7)
+      '@babel/plugin-transform-object-super': 7.18.6(@babel/core@7.23.7)
+      '@babel/plugin-transform-parameters': 7.20.5(@babel/core@7.23.7)
+      '@babel/plugin-transform-property-literals': 7.18.6(@babel/core@7.23.7)
+      '@babel/plugin-transform-react-display-name': 7.18.6(@babel/core@7.23.7)
+      '@babel/plugin-transform-react-jsx': 7.19.0(@babel/core@7.23.7)
+      '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.23.7)
+      '@babel/plugin-transform-spread': 7.19.0(@babel/core@7.23.7)
+      '@babel/plugin-transform-template-literals': 7.18.9(@babel/core@7.23.7)
       babel-plugin-syntax-trailing-function-commas: 7.0.0-beta.0
     dev: true
 
@@ -2689,15 +2681,15 @@ packages:
       wcwidth: 1.0.1
     dev: true
 
-  /browserslist@4.22.1:
-    resolution: {integrity: sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==}
+  /browserslist@4.22.2:
+    resolution: {integrity: sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001564
-      electron-to-chromium: 1.4.593
-      node-releases: 2.0.13
-      update-browserslist-db: 1.0.13(browserslist@4.22.1)
+      caniuse-lite: 1.0.30001576
+      electron-to-chromium: 1.4.630
+      node-releases: 2.0.14
+      update-browserslist-db: 1.0.13(browserslist@4.22.2)
     dev: true
 
   /bser@2.1.1:
@@ -2768,8 +2760,8 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /caniuse-lite@1.0.30001564:
-    resolution: {integrity: sha512-DqAOf+rhof+6GVx1y+xzbFPeOumfQnhYzVnZD6LAXijR77yPtm9mfOcqOnT3mpnJiZVT+kwLAFnRlZcIz+c6bg==}
+  /caniuse-lite@1.0.30001576:
+    resolution: {integrity: sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==}
     dev: true
 
   /capital-case@1.0.4:
@@ -3202,8 +3194,8 @@ packages:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
     dev: true
 
-  /electron-to-chromium@1.4.593:
-    resolution: {integrity: sha512-c7+Hhj87zWmdpmjDONbvNKNo24tvmD4mjal1+qqTYTrlF0/sNpAcDlU0Ki84ftA/5yj3BF2QhSGEC0Rky6larg==}
+  /electron-to-chromium@1.4.630:
+    resolution: {integrity: sha512-osHqhtjojpCsACVnuD11xO5g9xaCyw7Qqn/C2KParkMv42i8jrJJgx3g7mkHfpxwhy9MnOJr8+pKOdZ7qzgizg==}
     dev: true
 
   /emoji-regex@8.0.0:
@@ -3630,8 +3622,8 @@ packages:
       get-intrinsic: 1.2.2
     dev: true
 
-  /gql.tada@1.0.0-beta.1(graphql@16.8.1):
-    resolution: {integrity: sha512-jodWt1sV8ORYp8FyY8+bGXAalRoyAqjk6kAZfewZgTuFZ8v/F70yujqxQ0KSdajzFK2SLsOSPEI+QXv+Nln9EQ==}
+  /gql.tada@1.0.0-beta.2(graphql@16.8.1):
+    resolution: {integrity: sha512-P8K2zGEitLoYZzTJhOqfKX0sdFH17E+9wnQv/zLRJl+FORRdi70JtFxLslkez+vhVLSA57sccRyWICbI/Z70hA==}
     dependencies:
       '@0no-co/graphql.web': 1.0.4(graphql@16.8.1)
     transitivePeerDependencies:
@@ -4586,8 +4578,8 @@ packages:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
     dev: true
 
-  /node-releases@2.0.13:
-    resolution: {integrity: sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==}
+  /node-releases@2.0.14:
+    resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
     dev: true
 
   /normalize-package-data@2.5.0:
@@ -4771,7 +4763,7 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/code-frame': 7.23.4
+      '@babel/code-frame': 7.23.5
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -5116,7 +5108,7 @@ packages:
       rollup: 4.9.5
       typescript: 5.3.3
     optionalDependencies:
-      '@babel/code-frame': 7.23.4
+      '@babel/code-frame': 7.23.5
     dev: true
 
   /rollup@4.9.5:
@@ -5729,13 +5721,13 @@ packages:
       normalize-path: 2.1.1
     dev: true
 
-  /update-browserslist-db@1.0.13(browserslist@4.22.1):
+  /update-browserslist-db@1.0.13(browserslist@4.22.2):
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
     dependencies:
-      browserslist: 4.22.1
+      browserslist: 4.22.2
       escalade: 3.1.1
       picocolors: 1.0.0
     dev: true
@@ -6147,8 +6139,6 @@ packages:
     resolution: {directory: packages/graphqlsp, type: directory}
     name: '@0no-co/graphqlsp'
     dependencies:
-      '@sindresorhus/fnv1a': 2.0.1
-      lru-cache: 10.0.1
       node-fetch: 2.6.7
     transitivePeerDependencies:
       - encoding


### PR DESCRIPTION
## Summary

This allows us to save to a filename directly as part of the `tadaOutputLocation` format.
When a directory is given the `introspection.d.ts` filename is appended and a `d.ts`-type output is created. When a filename is given, it checks for `.ts` or `.d.ts` and uses the corresponding format.

Depending on which format is used, the output will differ slightly. The `.d.ts` file format will aim to declare the introspection type directly into `gql.tada`, minimising the amount of setup that's needed.

When the `.ts` format is used, only a variable is exported from it for the introspection, as before. To help with setup steps, TSDocs are added to the output that show the user how to use the output files.

## Set of changes

- Reformat `loadSchema` to extract identical code paths
- Reconcile saving introspections to `saveTadaIntrospection`
- Add file formats for `.d.ts` and `.ts` (new version of `gql.tada` needed for `.d.ts`; ~to be released~)
- Add schema minification in case schema is saved to `.ts` and reused
- Allow `tadaOutputLocation` to target files directly and create files as needed