### PR TITLE
fix(field usage): avoid checking usage multiple times

### DIFF
--- a/.changeset/new-feet-travel.md
+++ b/.changeset/new-feet-travel.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Ensure we track usage across all references

--- a/packages/example-tada/introspection.ts
+++ b/packages/example-tada/introspection.ts
@@ -8,7 +8,7 @@
  * @example
  * ```
  * import { initGraphQLTada } from 'gql.tada';
- * import { introspection } from './introspection';
+ * import type { introspection } from './introspection';
  *
  * export const graphql = initGraphQLTada<{
  *   introspection: typeof introspection;

--- a/packages/graphqlsp/src/fieldUsage.ts
+++ b/packages/graphqlsp/src/fieldUsage.ts
@@ -2,7 +2,6 @@ import { ts } from './ts';
 import { parse, visit } from 'graphql';
 
 import { findNode } from './ast';
-import { Logger } from '.';
 
 export const UNUSED_FIELD_CODE = 52005;
 
@@ -176,14 +175,10 @@ export const checkFieldUsageInFile = (
   nodes: ts.NoSubstitutionTemplateLiteral[],
   info: ts.server.PluginCreateInfo
 ) => {
-  const logger: Logger = (msg: string) =>
-    info.project.projectService.logger.info(`[GraphQLSP] ${msg}`);
   const diagnostics: ts.Diagnostic[] = [];
   const shouldTrackFieldUsage = info.config.trackFieldUsage ?? true;
   if (!shouldTrackFieldUsage) return diagnostics;
 
-  logger(`Checking field usage in ${source.fileName}`);
-  logger(`Found: ${nodes.map(n => n.getText()).join(', ')}`);
   nodes.forEach(node => {
     const nodeText = node.getText();
     // Bailing for mutations/subscriptions as these could have small details
@@ -244,7 +239,6 @@ export const checkFieldUsageInFile = (
     });
 
     references.forEach(ref => {
-      logger(`file: ${ref.fileName}`);
       if (ref.fileName !== source.fileName) return;
 
       let found = findNode(source, ref.textSpan.start);

--- a/packages/graphqlsp/src/fieldUsage.ts
+++ b/packages/graphqlsp/src/fieldUsage.ts
@@ -2,6 +2,7 @@ import { ts } from './ts';
 import { parse, visit } from 'graphql';
 
 import { findNode } from './ast';
+import { Logger } from '.';
 
 export const UNUSED_FIELD_CODE = 52005;
 
@@ -175,10 +176,14 @@ export const checkFieldUsageInFile = (
   nodes: ts.NoSubstitutionTemplateLiteral[],
   info: ts.server.PluginCreateInfo
 ) => {
+  const logger: Logger = (msg: string) =>
+    info.project.projectService.logger.info(`[GraphQLSP] ${msg}`);
   const diagnostics: ts.Diagnostic[] = [];
   const shouldTrackFieldUsage = info.config.trackFieldUsage ?? true;
   if (!shouldTrackFieldUsage) return diagnostics;
 
+  logger(`Checking field usage in ${source.fileName}`);
+  logger(`Found: ${nodes.map(n => n.getText()).join(', ')}`);
   nodes.forEach(node => {
     const nodeText = node.getText();
     // Bailing for mutations/subscriptions as these could have small details
@@ -195,7 +200,51 @@ export const checkFieldUsageInFile = (
     );
     if (!references) return;
 
+    const allAccess: string[] = [];
+    const inProgress: string[] = [];
+    const allPaths: string[] = [];
+    const allFields: string[] = [];
+    const reserved = ['id', '__typename'];
+    const fieldToLoc = new Map<string, { start: number; length: number }>();
+    // This visitor gets all the leaf-paths in the document
+    // as well as all fields that are part of the document
+    // We need the leaf-paths to check usage and we need the
+    // fields to validate whether an access on a given reference
+    // is valid given the current document...
+    visit(parse(node.getText().slice(1, -1)), {
+      Field: {
+        enter: node => {
+          if (!reserved.includes(node.name.value)) {
+            allFields.push(node.name.value);
+          }
+
+          if (!node.selectionSet && !reserved.includes(node.name.value)) {
+            let p;
+            if (inProgress.length) {
+              p = inProgress.join('.') + '.' + node.name.value;
+            } else {
+              p = node.name.value;
+            }
+            allPaths.push(p);
+
+            fieldToLoc.set(p, {
+              start: node.name.loc!.start,
+              length: node.name.loc!.end - node.name.loc!.start,
+            });
+          } else if (node.selectionSet) {
+            inProgress.push(node.name.value);
+          }
+        },
+        leave: node => {
+          if (node.selectionSet) {
+            inProgress.pop();
+          }
+        },
+      },
+    });
+
     references.forEach(ref => {
+      logger(`file: ${ref.fileName}`);
       if (ref.fileName !== source.fileName) return;
 
       let found = findNode(source, ref.textSpan.start);
@@ -208,48 +257,6 @@ export const checkFieldUsageInFile = (
       const [output] = found.declarationList.declarations;
 
       if (output.name.getText() === variableDeclaration.name.getText()) return;
-
-      const inProgress: string[] = [];
-      const allPaths: string[] = [];
-      const allFields: string[] = [];
-      const reserved = ['id', '__typename'];
-      const fieldToLoc = new Map<string, { start: number; length: number }>();
-      // This visitor gets all the leaf-paths in the document
-      // as well as all fields that are part of the document
-      // We need the leaf-paths to check usage and we need the
-      // fields to validate whether an access on a given reference
-      // is valid given the current document...
-      visit(parse(node.getText().slice(1, -1)), {
-        Field: {
-          enter: node => {
-            if (!reserved.includes(node.name.value)) {
-              allFields.push(node.name.value);
-            }
-
-            if (!node.selectionSet && !reserved.includes(node.name.value)) {
-              let p;
-              if (inProgress.length) {
-                p = inProgress.join('.') + '.' + node.name.value;
-              } else {
-                p = node.name.value;
-              }
-              allPaths.push(p);
-
-              fieldToLoc.set(p, {
-                start: node.name.loc!.start,
-                length: node.name.loc!.end - node.name.loc!.start,
-              });
-            } else if (node.selectionSet) {
-              inProgress.push(node.name.value);
-            }
-          },
-          leave: node => {
-            if (node.selectionSet) {
-              inProgress.pop();
-            }
-          },
-        },
-      });
 
       let temp = output.name;
       // Supported cases:
@@ -266,26 +273,28 @@ export const checkFieldUsageInFile = (
         temp = temp.elements[0].name;
       }
 
-      let allAccess: string[] = [];
       if (ts.isObjectBindingPattern(temp)) {
-        allAccess = traverseDestructuring(temp, [], allFields, source, info);
+        const result = traverseDestructuring(temp, [], allFields, source, info);
+        allAccess.push(...result);
       } else {
-        allAccess = crawlScope(temp, [], allFields, source, info);
+        const result = crawlScope(temp, [], allFields, source, info);
+        allAccess.push(...result);
       }
+    });
 
-      const unused = allPaths.filter(x => !allAccess.includes(x));
-      unused.forEach(unusedField => {
-        const loc = fieldToLoc.get(unusedField);
-        if (!loc) return;
+    const unused = allPaths.filter(x => !allAccess.includes(x));
 
-        diagnostics.push({
-          file: source,
-          length: loc.length,
-          start: node.getStart() + loc.start + 1,
-          category: ts.DiagnosticCategory.Warning,
-          code: UNUSED_FIELD_CODE,
-          messageText: `Field '${unusedField}' is not used.`,
-        });
+    unused.forEach(unusedField => {
+      const loc = fieldToLoc.get(unusedField);
+      if (!loc) return;
+
+      diagnostics.push({
+        file: source,
+        length: loc.length,
+        start: node.getStart() + loc.start + 1,
+        category: ts.DiagnosticCategory.Warning,
+        code: UNUSED_FIELD_CODE,
+        messageText: `Field '${unusedField}' is not used.`,
       });
     });
   });

--- a/test/e2e/fixture-project-client-preset/tsconfig.json
+++ b/test/e2e/fixture-project-client-preset/tsconfig.json
@@ -5,7 +5,7 @@
         "name": "@0no-co/graphqlsp",
         "schema": "./schema.graphql",
         "disableTypegen": true,
-        "shouldCheckForColocatedFragments": true
+        "trackFieldUsage": false
       }
     ],
     "target": "es2016",


### PR DESCRIPTION
In tada when doing

```js
export const Pokemon = ({ data }: { data: FragmentOf<typeof Fragment>}) => {
```

We would analyse references on Pokemon for the fragment, to counter act this we'll check all field usage in total across references