### PR TITLE
fix: avoid diagnostics for fragment imports and field-usage

### DIFF
--- a/.changeset/wild-lizards-fry.md
+++ b/.changeset/wild-lizards-fry.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Stop caching diagnostics for fragment imports and field-usage as these can be controlled externally

--- a/packages/graphqlsp/src/diagnostics.ts
+++ b/packages/graphqlsp/src/diagnostics.ts
@@ -43,10 +43,7 @@ export const SEMANTIC_DIAGNOSTIC_CODE = 52001;
 export const MISSING_OPERATION_NAME_CODE = 52002;
 export const USING_DEPRECATED_FIELD_CODE = 52004;
 
-const cache = new LRUCache<
-  number,
-  Array<Diagnostic & { length: number; start: number }>
->({
+const cache = new LRUCache<number, ts.Diagnostic[]>({
   // how long to live in ms
   ttl: 1000 * 60 * 15,
   max: 5000,
@@ -72,23 +69,6 @@ export function getGraphQLDiagnostics(
     nodes = findAllTaggedTemplateNodes(source);
   }
 
-  return runDiagnostics(source, { nodes, fragments }, schema, info);
-}
-
-const runDiagnostics = (
-  source: ts.SourceFile,
-  {
-    nodes,
-    fragments,
-  }: {
-    nodes: (ts.TaggedTemplateExpression | ts.NoSubstitutionTemplateLiteral)[];
-    fragments: FragmentDefinitionNode[];
-  },
-  schema: { current: GraphQLSchema | null; version: number },
-  info: ts.server.PluginCreateInfo
-) => {
-  const isCallExpression = info.config.templateIsCallExpression ?? true;
-
   const texts = nodes.map(node => {
     if (
       (ts.isNoSubstitutionTemplateLiteral(node) ||
@@ -113,172 +93,233 @@ const runDiagnostics = (
       : texts.join('-') + schema.version
   );
 
-  const filename = source.fileName;
-
-  const diagnostics = cache.has(cacheKey)
-    ? cache.get(cacheKey)!
-    : (nodes
-        .map(originalNode => {
-          let node = originalNode;
-          if (
-            !isCallExpression &&
-            (ts.isNoSubstitutionTemplateLiteral(node) ||
-              ts.isTemplateExpression(node))
-          ) {
-            if (ts.isTaggedTemplateExpression(node.parent)) {
-              node = node.parent;
-            } else {
-              return undefined;
-            }
-          }
-
-          const { combinedText: text, resolvedSpans } = resolveTemplate(
-            node,
-            filename,
-            info
-          );
-          const lines = text.split('\n');
-
-          let isExpression = false;
-          if (ts.isAsExpression(node.parent)) {
-            if (ts.isExpressionStatement(node.parent.parent)) {
-              isExpression = true;
-            }
-          } else if (ts.isExpressionStatement(node.parent)) {
-            isExpression = true;
-          }
-          // When we are dealing with a plain gql statement we have to add two these can be recognised
-          // by the fact that the parent is an expressionStatement
-
-          let startingPosition =
-            node.pos +
-            (isCallExpression
-              ? 0
-              : (node as ts.TaggedTemplateExpression).tag.getText().length +
-                (isExpression ? 2 : 1));
-          const endPosition = startingPosition + node.getText().length;
-
-          let docFragments = [...fragments];
-          if (isCallExpression) {
-            try {
-              const documentFragments = parse(text, {
-                noLocation: true,
-              }).definitions.filter(x => x.kind === Kind.FRAGMENT_DEFINITION);
-              docFragments = docFragments.filter(
-                x =>
-                  !documentFragments.some(
-                    y =>
-                      y.kind === Kind.FRAGMENT_DEFINITION &&
-                      y.name.value === x.name.value
-                  )
-              );
-            } catch (e) {}
-          }
-
-          const graphQLDiagnostics = getDiagnostics(
-            text,
-            schema.current,
-            undefined,
-            undefined,
-            docFragments
-          )
-            .filter(diag => {
-              if (!diag.message.includes('Unknown directive')) return true;
-
-              const [message] = diag.message.split('(');
-              const matches = directiveRegex.exec(message);
-              if (!matches) return true;
-              const directiveNmae = matches[1];
-              return !clientDirectives.has(directiveNmae);
-            })
-            .map(x => {
-              const { start, end } = x.range;
-
-              // We add the start.line to account for newline characters which are
-              // split out
-              let startChar = startingPosition + start.line;
-              for (let i = 0; i <= start.line; i++) {
-                if (i === start.line) startChar += start.character;
-                else startChar += lines[i].length;
-              }
-
-              let endChar = startingPosition + end.line;
-              for (let i = 0; i <= end.line; i++) {
-                if (i === end.line) endChar += end.character;
-                else endChar += lines[i].length;
-              }
-
-              const locatedInFragment = resolvedSpans.find(x => {
-                const newEnd = x.new.start + x.new.length;
-                return startChar >= x.new.start && endChar <= newEnd;
-              });
-
-              if (!!locatedInFragment) {
-                return {
-                  ...x,
-                  start: locatedInFragment.original.start,
-                  length: locatedInFragment.original.length,
-                };
-              } else {
-                if (startChar > endPosition) {
-                  // we have to calculate the added length and fix this
-                  const addedCharacters = resolvedSpans
-                    .filter(x => x.new.start + x.new.length < startChar)
-                    .reduce(
-                      (acc, span) =>
-                        acc + (span.new.length - span.original.length),
-                      0
-                    );
-                  startChar = startChar - addedCharacters;
-                  endChar = endChar - addedCharacters;
-                  return {
-                    ...x,
-                    start: startChar + 1,
-                    length: endChar - startChar,
-                  };
-                } else {
-                  return {
-                    ...x,
-                    start: startChar + 1,
-                    length: endChar - startChar,
-                  };
-                }
-              }
-            })
-            .filter(x => x.start + x.length <= endPosition);
-
-          try {
-            const parsed = parse(text, { noLocation: true });
-
-            if (
-              parsed.definitions.some(x => x.kind === Kind.OPERATION_DEFINITION)
-            ) {
-              const op = parsed.definitions.find(
-                x => x.kind === Kind.OPERATION_DEFINITION
-              ) as OperationDefinitionNode;
-              if (!op.name) {
-                graphQLDiagnostics.push({
-                  message: 'Operation needs a name for types to be generated.',
-                  start: node.pos,
-                  code: MISSING_OPERATION_NAME_CODE,
-                  length: originalNode.getText().length,
-                  range: {} as any,
-                  severity: 2,
-                } as any);
-              }
-            }
-          } catch (e) {}
-
-          return graphQLDiagnostics;
-        })
-        .flat()
-        .filter(Boolean) as Array<
-        Diagnostic & { length: number; start: number }
-      >);
-
-  if (!cache.has(cacheKey)) {
-    cache.set(cacheKey, diagnostics);
+  let tsDiagnostics;
+  if (cache.has(cacheKey)) {
+    tsDiagnostics = cache.get(cacheKey)!;
+  } else {
+    tsDiagnostics = runDiagnostics(source, { nodes, fragments }, schema, info);
+    cache.set(cacheKey, tsDiagnostics);
   }
+
+  const shouldCheckForColocatedFragments =
+    info.config.shouldCheckForColocatedFragments ?? true;
+  let fragmentDiagnostics: ts.Diagnostic[] = [];
+  if (isCallExpression && shouldCheckForColocatedFragments) {
+    const moduleSpecifierToFragments = getColocatedFragmentNames(source, info);
+
+    const usedFragments = new Set();
+    nodes.forEach(node => {
+      try {
+        const parsed = parse(node.getText().slice(1, -1), {
+          noLocation: true,
+        });
+        visit(parsed, {
+          FragmentSpread: node => {
+            usedFragments.add(node.name.value);
+          },
+        });
+      } catch (e) {}
+    });
+
+    Object.keys(moduleSpecifierToFragments).forEach(moduleSpecifier => {
+      const {
+        fragments: fragmentNames,
+        start,
+        length,
+      } = moduleSpecifierToFragments[moduleSpecifier];
+      const missingFragments = Array.from(
+        new Set(fragmentNames.filter(x => !usedFragments.has(x)))
+      );
+      if (missingFragments.length) {
+        fragmentDiagnostics.push({
+          file: source,
+          length,
+          start,
+          category: ts.DiagnosticCategory.Warning,
+          code: MISSING_FRAGMENT_CODE,
+          messageText: `Unused co-located fragment definition(s) "${missingFragments.join(
+            ', '
+          )}" in ${moduleSpecifier}`,
+        });
+      }
+    });
+
+    return [...tsDiagnostics, ...fragmentDiagnostics];
+  } else {
+    return tsDiagnostics;
+  }
+}
+
+const runDiagnostics = (
+  source: ts.SourceFile,
+  {
+    nodes,
+    fragments,
+  }: {
+    nodes: (ts.TaggedTemplateExpression | ts.NoSubstitutionTemplateLiteral)[];
+    fragments: FragmentDefinitionNode[];
+  },
+  schema: { current: GraphQLSchema | null; version: number },
+  info: ts.server.PluginCreateInfo
+) => {
+  const filename = source.fileName;
+  const isCallExpression = info.config.templateIsCallExpression ?? true;
+
+  const diagnostics = nodes
+    .map(originalNode => {
+      let node = originalNode;
+      if (
+        !isCallExpression &&
+        (ts.isNoSubstitutionTemplateLiteral(node) ||
+          ts.isTemplateExpression(node))
+      ) {
+        if (ts.isTaggedTemplateExpression(node.parent)) {
+          node = node.parent;
+        } else {
+          return undefined;
+        }
+      }
+
+      const { combinedText: text, resolvedSpans } = resolveTemplate(
+        node,
+        filename,
+        info
+      );
+      const lines = text.split('\n');
+
+      let isExpression = false;
+      if (ts.isAsExpression(node.parent)) {
+        if (ts.isExpressionStatement(node.parent.parent)) {
+          isExpression = true;
+        }
+      } else if (ts.isExpressionStatement(node.parent)) {
+        isExpression = true;
+      }
+      // When we are dealing with a plain gql statement we have to add two these can be recognised
+      // by the fact that the parent is an expressionStatement
+
+      let startingPosition =
+        node.pos +
+        (isCallExpression
+          ? 0
+          : (node as ts.TaggedTemplateExpression).tag.getText().length +
+            (isExpression ? 2 : 1));
+      const endPosition = startingPosition + node.getText().length;
+
+      let docFragments = [...fragments];
+      if (isCallExpression) {
+        try {
+          const documentFragments = parse(text, {
+            noLocation: true,
+          }).definitions.filter(x => x.kind === Kind.FRAGMENT_DEFINITION);
+          docFragments = docFragments.filter(
+            x =>
+              !documentFragments.some(
+                y =>
+                  y.kind === Kind.FRAGMENT_DEFINITION &&
+                  y.name.value === x.name.value
+              )
+          );
+        } catch (e) {}
+      }
+
+      const graphQLDiagnostics = getDiagnostics(
+        text,
+        schema.current,
+        undefined,
+        undefined,
+        docFragments
+      )
+        .filter(diag => {
+          if (!diag.message.includes('Unknown directive')) return true;
+
+          const [message] = diag.message.split('(');
+          const matches = directiveRegex.exec(message);
+          if (!matches) return true;
+          const directiveNmae = matches[1];
+          return !clientDirectives.has(directiveNmae);
+        })
+        .map(x => {
+          const { start, end } = x.range;
+
+          // We add the start.line to account for newline characters which are
+          // split out
+          let startChar = startingPosition + start.line;
+          for (let i = 0; i <= start.line; i++) {
+            if (i === start.line) startChar += start.character;
+            else startChar += lines[i].length;
+          }
+
+          let endChar = startingPosition + end.line;
+          for (let i = 0; i <= end.line; i++) {
+            if (i === end.line) endChar += end.character;
+            else endChar += lines[i].length;
+          }
+
+          const locatedInFragment = resolvedSpans.find(x => {
+            const newEnd = x.new.start + x.new.length;
+            return startChar >= x.new.start && endChar <= newEnd;
+          });
+
+          if (!!locatedInFragment) {
+            return {
+              ...x,
+              start: locatedInFragment.original.start,
+              length: locatedInFragment.original.length,
+            };
+          } else {
+            if (startChar > endPosition) {
+              // we have to calculate the added length and fix this
+              const addedCharacters = resolvedSpans
+                .filter(x => x.new.start + x.new.length < startChar)
+                .reduce(
+                  (acc, span) => acc + (span.new.length - span.original.length),
+                  0
+                );
+              startChar = startChar - addedCharacters;
+              endChar = endChar - addedCharacters;
+              return {
+                ...x,
+                start: startChar + 1,
+                length: endChar - startChar,
+              };
+            } else {
+              return {
+                ...x,
+                start: startChar + 1,
+                length: endChar - startChar,
+              };
+            }
+          }
+        })
+        .filter(x => x.start + x.length <= endPosition);
+
+      try {
+        const parsed = parse(text, { noLocation: true });
+
+        if (
+          parsed.definitions.some(x => x.kind === Kind.OPERATION_DEFINITION)
+        ) {
+          const op = parsed.definitions.find(
+            x => x.kind === Kind.OPERATION_DEFINITION
+          ) as OperationDefinitionNode;
+          if (!op.name) {
+            graphQLDiagnostics.push({
+              message: 'Operation needs a name for types to be generated.',
+              start: node.pos,
+              code: MISSING_OPERATION_NAME_CODE,
+              length: originalNode.getText().length,
+              range: {} as any,
+              severity: 2,
+            } as any);
+          }
+        }
+      } catch (e) {}
+
+      return graphQLDiagnostics;
+    })
+    .flat()
+    .filter(Boolean) as Array<Diagnostic & { length: number; start: number }>;
 
   const tsDiagnostics = diagnostics.map(diag => ({
     file: source,
@@ -304,54 +345,7 @@ const runDiagnostics = (
       info
     );
 
-    const shouldCheckForColocatedFragments =
-      info.config.shouldCheckForColocatedFragments ?? true;
-    let fragmentDiagnostics: ts.Diagnostic[] = [];
-    if (shouldCheckForColocatedFragments) {
-      const moduleSpecifierToFragments = getColocatedFragmentNames(
-        source,
-        info
-      );
-
-      const usedFragments = new Set();
-      nodes.forEach(node => {
-        try {
-          const parsed = parse(node.getText().slice(1, -1), {
-            noLocation: true,
-          });
-          visit(parsed, {
-            FragmentSpread: node => {
-              usedFragments.add(node.name.value);
-            },
-          });
-        } catch (e) {}
-      });
-
-      Object.keys(moduleSpecifierToFragments).forEach(moduleSpecifier => {
-        const {
-          fragments: fragmentNames,
-          start,
-          length,
-        } = moduleSpecifierToFragments[moduleSpecifier];
-        const missingFragments = Array.from(
-          new Set(fragmentNames.filter(x => !usedFragments.has(x)))
-        );
-        if (missingFragments.length) {
-          fragmentDiagnostics.push({
-            file: source,
-            length,
-            start,
-            category: ts.DiagnosticCategory.Warning,
-            code: MISSING_FRAGMENT_CODE,
-            messageText: `Unused co-located fragment definition(s) "${missingFragments.join(
-              ', '
-            )}" in ${moduleSpecifier}`,
-          });
-        }
-      });
-    }
-
-    return [...tsDiagnostics, ...usageDiagnostics, ...fragmentDiagnostics];
+    return [...tsDiagnostics, ...usageDiagnostics];
   } else {
     return tsDiagnostics;
   }

--- a/test/e2e/server.ts
+++ b/test/e2e/server.ts
@@ -1,7 +1,5 @@
 import { ChildProcess, fork } from 'node:child_process';
-import path from 'node:path';
 import readline from 'node:readline';
-import fs from 'node:fs';
 import ts from 'typescript/lib/tsserverlibrary';
 
 type Command = `${ts.server.protocol.CommandTypes}`;


### PR DESCRIPTION
Stop caching diagnostics for fragment imports and field-usage as these can be controlled externally, only caching the source-texts diagnostics