### PR TITLE
fix: Export introspection type in d.ts output

### DIFF
--- a/.changeset/hot-icons-fetch.md
+++ b/.changeset/hot-icons-fetch.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+When creating a `d.ts` file, export the introspection type to make it reusable.

--- a/packages/graphqlsp/src/graphql/getSchema.ts
+++ b/packages/graphqlsp/src/graphql/getSchema.ts
@@ -99,7 +99,7 @@ async function saveTadaIntrospection(
   if (/\.d\.ts$/.test(output)) {
     contents = [
       dtsAnnotationComment,
-      `export const type introspection = ${json};\n`,
+      `export type introspection = ${json};\n`,
       "import * as gqlTada from 'gql.tada';\n",
       "declare module 'gql.tada' {",
       '  interface setupSchema {',

--- a/packages/graphqlsp/src/graphql/getSchema.ts
+++ b/packages/graphqlsp/src/graphql/getSchema.ts
@@ -99,11 +99,11 @@ async function saveTadaIntrospection(
   if (/\.d\.ts$/.test(output)) {
     contents = [
       dtsAnnotationComment,
-      `declare const introspection: ${json};\n`,
+      `export const type introspection = ${json};\n`,
       "import * as gqlTada from 'gql.tada';\n",
       "declare module 'gql.tada' {",
       '  interface setupSchema {',
-      '    introspection: typeof introspection',
+      '    introspection: introspection',
       '  }',
       '}',
     ].join('\n');


### PR DESCRIPTION
This exports `export type introspection` in `d.ts` files so it can be reused.

This is important because it's much more performant on huge schemas than a `typeof introspection`, so providing this alternative is really valuable.