### PR TITLE
fix: Upgrade to @urql/introspection@1.0.3

### DIFF
--- a/.changeset/orange-dodos-grab.md
+++ b/.changeset/orange-dodos-grab.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Upgrade to `@urql/introspection@1.0.3`

--- a/packages/graphqlsp/package.json
+++ b/packages/graphqlsp/package.json
@@ -40,7 +40,7 @@
     "@sindresorhus/fnv1a": "^2.0.0",
     "@types/node": "^18.15.11",
     "@types/node-fetch": "^2.6.3",
-    "@urql/introspection": "^1.0.2",
+    "@urql/introspection": "^1.0.3",
     "graphql": "^16.8.1",
     "graphql-language-service": "^5.2.0",
     "lru-cache": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,8 +184,8 @@ importers:
         specifier: ^2.6.3
         version: 2.6.3
       '@urql/introspection':
-        specifier: ^1.0.2
-        version: 1.0.2(graphql@16.8.1)
+        specifier: ^1.0.3
+        version: 1.0.3(graphql@16.8.1)
       graphql:
         specifier: ^16.8.1
         version: 16.8.1
@@ -2343,8 +2343,8 @@ packages:
       - graphql
     dev: false
 
-  /@urql/introspection@1.0.2(graphql@16.8.1):
-    resolution: {integrity: sha512-vPuX+DjbmL5EUsvwgAMV8dkxc7JKuuNTzDfsNvtCuVmbAED4Nx39p08HImjTWAewSatjyzZZs+fAhU7z/4P+UQ==}
+  /@urql/introspection@1.0.3(graphql@16.8.1):
+    resolution: {integrity: sha512-5zgnfUDV10c3qudqYvfZ/rOtWVB2QvqanmoDMttqpt+TCCPkSUZdb2qcLCEB6DL7ph8mQRTZhXI29J57nTnqKg==}
     peerDependencies:
       graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:


### PR DESCRIPTION
`@urql/introspection@1.0.3` fixes redundant `Any` types being added to the introspection output. These weren't needed with the options we passed into `minifyIntrospectionQuery`, but were added by the utility anyway.