### PR TITLE
fix: Add prettier/eslint disable comments to output

### DIFF
--- a/.changeset/yellow-pianos-explode.md
+++ b/.changeset/yellow-pianos-explode.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Automatically disable Prettier and ESLint on `tadaOutputLocation` output files.

--- a/packages/graphqlsp/src/graphql/getSchema.ts
+++ b/packages/graphqlsp/src/graphql/getSchema.ts
@@ -14,6 +14,9 @@ import fs from 'fs';
 
 import { Logger } from '../index';
 
+const preambleComments =
+  ['/* eslint-disable */', '/* prettier-ignore */'].join('\n') + '\n';
+
 const dtsAnnotationComment = [
   '/** An IntrospectionQuery representation of your schema.',
   ' *',
@@ -98,6 +101,7 @@ async function saveTadaIntrospection(
 
   if (/\.d\.ts$/.test(output)) {
     contents = [
+      preambleComments,
       dtsAnnotationComment,
       `declare const introspection: ${json};\n`,
       "import * as gqlTada from 'gql.tada';\n",
@@ -109,6 +113,7 @@ async function saveTadaIntrospection(
     ].join('\n');
   } else if (path.extname(output) === '.ts') {
     contents = [
+      preambleComments,
       tsAnnotationComment,
       `const introspection = ${json} as const;\n`,
       'export { introspection };',


### PR DESCRIPTION
This adds a small preamble to output files:

```js
/* eslint-disable */
/* prettier-ignore */

```

...to disable Prettier and ESLint on them automatically.