### PR TITLE
feat(lsp): support prop assignment

### DIFF
--- a/.changeset/angry-eyes-occur.md
+++ b/.changeset/angry-eyes-occur.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': minor
+---
+
+support property assignment/objectAccessPattern

--- a/packages/example-tada/introspection.ts
+++ b/packages/example-tada/introspection.ts
@@ -1,3 +1,6 @@
+/* eslint-disable */
+/* prettier-ignore */
+
 /** An IntrospectionQuery representation of your schema.
  *
  * @remarks
@@ -20,426 +23,426 @@
  * ```
  */
 const introspection = {
-  __schema: {
-    queryType: {
-      name: 'Query',
+  "__schema": {
+    "queryType": {
+      "name": "Query"
     },
-    mutationType: null,
-    subscriptionType: null,
-    types: [
+    "mutationType": null,
+    "subscriptionType": null,
+    "types": [
       {
-        kind: 'OBJECT',
-        name: 'Attack',
-        fields: [
+        "kind": "OBJECT",
+        "name": "Attack",
+        "fields": [
           {
-            name: 'damage',
-            type: {
-              kind: 'SCALAR',
-              name: 'Int',
-              ofType: null,
+            "name": "damage",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
             },
-            args: [],
+            "args": []
           },
           {
-            name: 'name',
-            type: {
-              kind: 'SCALAR',
-              name: 'String',
-              ofType: null,
+            "name": "name",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
-            args: [],
+            "args": []
           },
           {
-            name: 'type',
-            type: {
-              kind: 'ENUM',
-              name: 'PokemonType',
-              ofType: null,
+            "name": "type",
+            "type": {
+              "kind": "ENUM",
+              "name": "PokemonType",
+              "ofType": null
             },
-            args: [],
-          },
+            "args": []
+          }
         ],
-        interfaces: [],
+        "interfaces": []
       },
       {
-        kind: 'SCALAR',
-        name: 'Int',
+        "kind": "SCALAR",
+        "name": "Int"
       },
       {
-        kind: 'SCALAR',
-        name: 'String',
+        "kind": "SCALAR",
+        "name": "String"
       },
       {
-        kind: 'OBJECT',
-        name: 'AttacksConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "AttacksConnection",
+        "fields": [
           {
-            name: 'fast',
-            type: {
-              kind: 'LIST',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'Attack',
-                ofType: null,
-              },
+            "name": "fast",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Attack",
+                "ofType": null
+              }
             },
-            args: [],
+            "args": []
           },
           {
-            name: 'special',
-            type: {
-              kind: 'LIST',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'Attack',
-                ofType: null,
-              },
+            "name": "special",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Attack",
+                "ofType": null
+              }
             },
-            args: [],
-          },
+            "args": []
+          }
         ],
-        interfaces: [],
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'EvolutionRequirement',
-        fields: [
+        "kind": "OBJECT",
+        "name": "EvolutionRequirement",
+        "fields": [
           {
-            name: 'amount',
-            type: {
-              kind: 'SCALAR',
-              name: 'Int',
-              ofType: null,
+            "name": "amount",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
             },
-            args: [],
+            "args": []
           },
           {
-            name: 'name',
-            type: {
-              kind: 'SCALAR',
-              name: 'String',
-              ofType: null,
+            "name": "name",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
-            args: [],
-          },
+            "args": []
+          }
         ],
-        interfaces: [],
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'Pokemon',
-        fields: [
+        "kind": "OBJECT",
+        "name": "Pokemon",
+        "fields": [
           {
-            name: 'attacks',
-            type: {
-              kind: 'OBJECT',
-              name: 'AttacksConnection',
-              ofType: null,
+            "name": "attacks",
+            "type": {
+              "kind": "OBJECT",
+              "name": "AttacksConnection",
+              "ofType": null
             },
-            args: [],
+            "args": []
           },
           {
-            name: 'classification',
-            type: {
-              kind: 'SCALAR',
-              name: 'String',
-              ofType: null,
+            "name": "classification",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
-            args: [],
+            "args": []
           },
           {
-            name: 'evolutionRequirements',
-            type: {
-              kind: 'LIST',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'EvolutionRequirement',
-                ofType: null,
-              },
+            "name": "evolutionRequirements",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "EvolutionRequirement",
+                "ofType": null
+              }
             },
-            args: [],
+            "args": []
           },
           {
-            name: 'evolutions',
-            type: {
-              kind: 'LIST',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'Pokemon',
-                ofType: null,
-              },
+            "name": "evolutions",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Pokemon",
+                "ofType": null
+              }
             },
-            args: [],
+            "args": []
           },
           {
-            name: 'fleeRate',
-            type: {
-              kind: 'SCALAR',
-              name: 'Float',
-              ofType: null,
+            "name": "fleeRate",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
             },
-            args: [],
+            "args": []
           },
           {
-            name: 'height',
-            type: {
-              kind: 'OBJECT',
-              name: 'PokemonDimension',
-              ofType: null,
+            "name": "height",
+            "type": {
+              "kind": "OBJECT",
+              "name": "PokemonDimension",
+              "ofType": null
             },
-            args: [],
+            "args": []
           },
           {
-            name: 'id',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'SCALAR',
-                name: 'ID',
-                ofType: null,
-              },
+            "name": "id",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
             },
-            args: [],
+            "args": []
           },
           {
-            name: 'maxCP',
-            type: {
-              kind: 'SCALAR',
-              name: 'Int',
-              ofType: null,
+            "name": "maxCP",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
             },
-            args: [],
+            "args": []
           },
           {
-            name: 'maxHP',
-            type: {
-              kind: 'SCALAR',
-              name: 'Int',
-              ofType: null,
+            "name": "maxHP",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
             },
-            args: [],
+            "args": []
           },
           {
-            name: 'name',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'SCALAR',
-                name: 'String',
-                ofType: null,
-              },
+            "name": "name",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
-            args: [],
+            "args": []
           },
           {
-            name: 'resistant',
-            type: {
-              kind: 'LIST',
-              ofType: {
-                kind: 'ENUM',
-                name: 'PokemonType',
-                ofType: null,
-              },
+            "name": "resistant",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "ENUM",
+                "name": "PokemonType",
+                "ofType": null
+              }
             },
-            args: [],
+            "args": []
           },
           {
-            name: 'types',
-            type: {
-              kind: 'LIST',
-              ofType: {
-                kind: 'ENUM',
-                name: 'PokemonType',
-                ofType: null,
-              },
+            "name": "types",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "ENUM",
+                "name": "PokemonType",
+                "ofType": null
+              }
             },
-            args: [],
+            "args": []
           },
           {
-            name: 'weaknesses',
-            type: {
-              kind: 'LIST',
-              ofType: {
-                kind: 'ENUM',
-                name: 'PokemonType',
-                ofType: null,
-              },
+            "name": "weaknesses",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "ENUM",
+                "name": "PokemonType",
+                "ofType": null
+              }
             },
-            args: [],
+            "args": []
           },
           {
-            name: 'weight',
-            type: {
-              kind: 'OBJECT',
-              name: 'PokemonDimension',
-              ofType: null,
+            "name": "weight",
+            "type": {
+              "kind": "OBJECT",
+              "name": "PokemonDimension",
+              "ofType": null
             },
-            args: [],
-          },
+            "args": []
+          }
         ],
-        interfaces: [],
+        "interfaces": []
       },
       {
-        kind: 'SCALAR',
-        name: 'Float',
+        "kind": "SCALAR",
+        "name": "Float"
       },
       {
-        kind: 'SCALAR',
-        name: 'ID',
+        "kind": "SCALAR",
+        "name": "ID"
       },
       {
-        kind: 'OBJECT',
-        name: 'PokemonDimension',
-        fields: [
+        "kind": "OBJECT",
+        "name": "PokemonDimension",
+        "fields": [
           {
-            name: 'maximum',
-            type: {
-              kind: 'SCALAR',
-              name: 'String',
-              ofType: null,
+            "name": "maximum",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
-            args: [],
+            "args": []
           },
           {
-            name: 'minimum',
-            type: {
-              kind: 'SCALAR',
-              name: 'String',
-              ofType: null,
+            "name": "minimum",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
-            args: [],
-          },
+            "args": []
+          }
         ],
-        interfaces: [],
+        "interfaces": []
       },
       {
-        kind: 'ENUM',
-        name: 'PokemonType',
-        enumValues: [
+        "kind": "ENUM",
+        "name": "PokemonType",
+        "enumValues": [
           {
-            name: 'Bug',
+            "name": "Bug"
           },
           {
-            name: 'Dark',
+            "name": "Dark"
           },
           {
-            name: 'Dragon',
+            "name": "Dragon"
           },
           {
-            name: 'Electric',
+            "name": "Electric"
           },
           {
-            name: 'Fairy',
+            "name": "Fairy"
           },
           {
-            name: 'Fighting',
+            "name": "Fighting"
           },
           {
-            name: 'Fire',
+            "name": "Fire"
           },
           {
-            name: 'Flying',
+            "name": "Flying"
           },
           {
-            name: 'Ghost',
+            "name": "Ghost"
           },
           {
-            name: 'Grass',
+            "name": "Grass"
           },
           {
-            name: 'Ground',
+            "name": "Ground"
           },
           {
-            name: 'Ice',
+            "name": "Ice"
           },
           {
-            name: 'Normal',
+            "name": "Normal"
           },
           {
-            name: 'Poison',
+            "name": "Poison"
           },
           {
-            name: 'Psychic',
+            "name": "Psychic"
           },
           {
-            name: 'Rock',
+            "name": "Rock"
           },
           {
-            name: 'Steel',
+            "name": "Steel"
           },
           {
-            name: 'Water',
-          },
-        ],
+            "name": "Water"
+          }
+        ]
       },
       {
-        kind: 'OBJECT',
-        name: 'Query',
-        fields: [
+        "kind": "OBJECT",
+        "name": "Query",
+        "fields": [
           {
-            name: 'pokemon',
-            type: {
-              kind: 'OBJECT',
-              name: 'Pokemon',
-              ofType: null,
+            "name": "pokemon",
+            "type": {
+              "kind": "OBJECT",
+              "name": "Pokemon",
+              "ofType": null
             },
-            args: [
+            "args": [
               {
-                name: 'id',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'ID',
-                    ofType: null,
-                  },
-                },
-              },
-            ],
+                "name": "id",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                }
+              }
+            ]
           },
           {
-            name: 'pokemons',
-            type: {
-              kind: 'LIST',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'Pokemon',
-                ofType: null,
-              },
+            "name": "pokemons",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Pokemon",
+                "ofType": null
+              }
             },
-            args: [
+            "args": [
               {
-                name: 'limit',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Int',
-                  ofType: null,
-                },
+                "name": "limit",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
               },
               {
-                name: 'skip',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Int',
-                  ofType: null,
-                },
-              },
-            ],
-          },
+                "name": "skip",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            ]
+          }
         ],
-        interfaces: [],
+        "interfaces": []
       },
       {
-        kind: 'SCALAR',
-        name: 'Boolean',
+        "kind": "SCALAR",
+        "name": "Boolean"
       },
       {
-        kind: 'SCALAR',
-        name: 'Any',
-      },
+        "kind": "SCALAR",
+        "name": "Any"
+      }
     ],
-    directives: [],
-  },
+    "directives": []
+  }
 } as const;
 
 export { introspection };

--- a/packages/example-tada/src/Pokemon.tsx
+++ b/packages/example-tada/src/Pokemon.tsx
@@ -1,5 +1,11 @@
 import { FragmentOf, graphql, readFragment } from './graphql';
 
+export const Fields = { Pokemon: graphql(`
+  fragment Pok on Pokemon {
+    resistant
+  }`)
+}
+
 export const PokemonFields = graphql(`
   fragment pokemonFields on Pokemon {
     name
@@ -10,18 +16,20 @@ export const PokemonFields = graphql(`
 `);
 
 interface Props {
-  data: FragmentOf<typeof PokemonFields> | null;
+  data: (FragmentOf<typeof PokemonFields> & FragmentOf<typeof Fields.Pokemon>) | null;
 }
 
 export const Pokemon = ({ data }: Props) => {
   const pokemon = readFragment(PokemonFields, data);
-  if (!pokemon) {
+  const resistant = readFragment(Fields.Pokemon, data);
+  if (!pokemon || !resistant) {
     return null;
   }
 
   return (
     <li>
       {pokemon.name}
+      {resistant.resistant}
     </li>
   );
 };

--- a/packages/example-tada/src/index.tsx
+++ b/packages/example-tada/src/index.tsx
@@ -1,6 +1,6 @@
 import { createClient, useQuery } from 'urql';
 import { graphql } from './graphql';
-import { Pokemon, PokemonFields } from './Pokemon';
+import { Fields, Pokemon, PokemonFields } from './Pokemon';
 
 const PokemonQuery = graphql(`
   query Po($id: ID!) {
@@ -8,6 +8,7 @@ const PokemonQuery = graphql(`
       id
       fleeRate
       ...pokemonFields
+      ...Pok
       attacks {
         special {
           name
@@ -28,7 +29,7 @@ const PokemonQuery = graphql(`
       types
     }
   }
-`, [PokemonFields]);
+`, [PokemonFields, Fields.Pokemon]);
 
 const Pokemons = () => {
   const [result] = useQuery({

--- a/packages/graphqlsp/src/ast/index.ts
+++ b/packages/graphqlsp/src/ast/index.ts
@@ -74,6 +74,8 @@ function unrollFragment(
     ts.isCallExpression(found.parent.initializer)
   ) {
     found = found.parent.initializer;
+  } else if (ts.isPropertyAssignment(found.parent)) {
+    found = found.parent.initializer;
   }
 
   if (ts.isCallExpression(found) && templates.has(found.expression.getText())) {
@@ -121,6 +123,15 @@ export function findAllCallExpressions(
         arg2.elements.forEach(element => {
           if (ts.isIdentifier(element)) {
             fragments.push(...unrollFragment(element, info));
+          } else if (ts.isPropertyAccessExpression(element)) {
+            let el = element;
+            while (ts.isPropertyAccessExpression(el.expression)) {
+              el = el.expression;
+            }
+
+            if (ts.isIdentifier(el.name)) {
+              fragments.push(...unrollFragment(el.name, info));
+            }
           }
         });
       }


### PR DESCRIPTION
When we were using `fields.pokemon` for instance we wouldn't immediately get to an identifier nor would the resulting reference be a variable-assignment.

We're still missing cases like `[...fragments]` and `[...Object.values(fragments)]`, ... but I wouldn't consider those great options and will tackle them when they pop up.

Resolves #201 