### PR TITLE
fix(tada): stop overriding the fragments array

### DIFF
--- a/.changeset/thick-monkeys-tan.md
+++ b/.changeset/thick-monkeys-tan.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Fix issue where a missing argument 2 for a call-expression would make us erase prior found fragment-definitions

--- a/packages/graphqlsp/src/ast/index.ts
+++ b/packages/graphqlsp/src/ast/index.ts
@@ -118,7 +118,7 @@ export function findAllCallExpressions(
 
       if (!hasTriedToFindFragments && !arg2) {
         hasTriedToFindFragments = true;
-        fragments = getAllFragments(sourceFile.fileName, node, info);
+        fragments.push(...getAllFragments(sourceFile.fileName, node, info));
       } else if (arg2 && ts.isArrayLiteralExpression(arg2)) {
         arg2.elements.forEach(element => {
           if (ts.isIdentifier(element)) {


### PR DESCRIPTION
fixes https://github.com/0no-co/GraphQLSP/issues/232

For the client-preset when we don't have a second argument we try to find all fragments as that uses global fragment definitions. This would clash with the tada workflow and override the fragments variable rather than pushing to it