### PR TITLE
feat: Expand tracking unused fields support to more cases

### DIFF
--- a/.changeset/tiny-snails-raise.md
+++ b/.changeset/tiny-snails-raise.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': minor
+---
+
+Expand support of tracking field usage to more edge cases by matching a defined GraphQL document’s type against variables in-scope with said type.


### PR DESCRIPTION
Resolves #229
Resolves #224

## Summary

Previously, the crawler tracking unused fields wasn't using the type checker to assist with its search of GraphQL data variables. This meant that we were carefully limiting the amount of cases we'd support.

However, as it's hard for us to account for every GraphQL client (that supports `TypedDocumentNode`) with every possible API (not just hooks, for example, or nested functions inside hooks), we now attempt to find a more general solution.

This PR, when merged, adds a new primary method of discovering where a GraphQL document is used. This new method finds variables in-scope at the point the document is referenced and then matches the type of these variables against the type of the document.
When a match is found, we then know to start tracking field usage for the given variable.

## Set of changes

- Find variables matching a document data types and prefer them to a direct AST check/traversal to find where to start tracking fields
- Add a case where destructuring is missing to cover `result` and `[result]` structures (as commonly returned by hooks)
- Keep the current method of traversing directly as a fallback case
- Fix cases where `crawlScope` wasn't unwrapping destructuring patterns
- Track functions when they're passed by reference to array methods