### PR TITLE
fix: Fix unused fields detection not respecting field aliases

### DIFF
--- a/.changeset/olive-trains-love.md
+++ b/.changeset/olive-trains-love.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Fix unused fields detection not respecting field aliases in GraphQL documents.

--- a/packages/graphqlsp/src/fieldUsage.ts
+++ b/packages/graphqlsp/src/fieldUsage.ts
@@ -362,25 +362,22 @@ export const checkFieldUsageInFile = (
       // is valid given the current document...
       visit(parse(node.getText().slice(1, -1)), {
         Field: {
-          enter: node => {
+          enter(node) {
+            const alias = node.alias ? node.alias.value : node.name.value;
             if (!node.selectionSet && !reservedKeys.has(node.name.value)) {
-              let p;
-              if (inProgress.length) {
-                p = inProgress.join('.') + '.' + node.name.value;
-              } else {
-                p = node.name.value;
-              }
-              allPaths.push(p);
-
-              fieldToLoc.set(p, {
+              const path = inProgress.length
+                ? `${inProgress.join('.')}.${alias}`
+                : alias;
+              allPaths.push(path);
+              fieldToLoc.set(path, {
                 start: node.name.loc!.start,
                 length: node.name.loc!.end - node.name.loc!.start,
               });
             } else if (node.selectionSet) {
-              inProgress.push(node.name.value);
+              inProgress.push(alias);
             }
           },
-          leave: node => {
+          leave(node) {
             if (node.selectionSet) {
               inProgress.pop();
             }


### PR DESCRIPTION
## Summary

The `visit` code that was computing field paths of a given GraphQL document wasn't handling field aliases before, causing all field aliases to be marked as unused in TypeScript code consuming data.

```ts
export const PokemonFields = graphql(/* GraphQL */`
  fragment pokemonFields on Pokemon {
    _name: name # marked as unused even if _name is accessed
    weight { 
      minimum
    }
  }
`);
```

## Set of changes

- Include `field.alias.value` when computing all paths of a document