### PR TITLE
feat: initial support for `graphql.persisted`

### DIFF
--- a/packages/example-tada/src/index.tsx
+++ b/packages/example-tada/src/index.tsx
@@ -1,4 +1,4 @@
-import { createClient, useQuery } from 'urql';
+import { useQuery } from 'urql';
 import { graphql } from './graphql';
 import { Fields, Pokemon, PokemonFields } from './Pokemon';
 
@@ -31,6 +31,8 @@ const PokemonQuery = graphql(`
     }
   }
 `, [PokemonFields, Fields.Pokemon]);
+
+const persisted = graphql.persisted<typeof PokemonQuery>("sha256:dc31ff9637bbc77bb95dffb2ca73b0e607639b018befd06e9ad801b54483d661")
 
 const Pokemons = () => {
   const [result] = useQuery({

--- a/packages/graphqlsp/src/api.ts
+++ b/packages/graphqlsp/src/api.ts
@@ -1,2 +1,3 @@
 export { getGraphQLDiagnostics } from './diagnostics';
 export { init } from './ts';
+export { findAllPersistedCallExpressions } from './ast';

--- a/packages/graphqlsp/src/ast/index.ts
+++ b/packages/graphqlsp/src/ast/index.ts
@@ -148,6 +148,29 @@ export function findAllCallExpressions(
   return { nodes: result, fragments };
 }
 
+export function findAllPersistedCallExpressions(
+  sourceFile: ts.SourceFile
+): Array<ts.CallExpression> {
+  const result: Array<ts.CallExpression> = [];
+  function find(node: ts.Node) {
+    if (ts.isCallExpression(node)) {
+      // This expression ideally for us looks like <template>.persisted
+      const expression = node.expression.getText();
+      const parts = expression.split('.');
+      if (parts.length !== 2) return;
+
+      const [template, method] = parts;
+      if (!templates.has(template) || method !== 'persisted') return;
+
+      result.push(node);
+    } else {
+      ts.forEachChild(node, find);
+    }
+  }
+  find(sourceFile);
+  return result;
+}
+
 export function getAllFragments(
   fileName: string,
   node: ts.CallExpression,

--- a/packages/graphqlsp/src/persisted.ts
+++ b/packages/graphqlsp/src/persisted.ts
@@ -1,0 +1,204 @@
+import { ts } from './ts';
+
+import { createHash } from 'crypto';
+
+import { findAllCallExpressions, findNode, getSource } from './ast';
+import { resolveTemplate } from './ast/resolve';
+import { templates } from './ast/templates';
+import { parse, print, visit } from '@0no-co/graphql.web';
+
+type PersistedAction = {
+  span: {
+    start: number;
+    length: number;
+  };
+  replacement: string;
+};
+
+const isPersistedCall = (expr: ts.LeftHandSideExpression) => {
+  const expressionText = expr.getText();
+  const [template, method] = expressionText.split('.');
+  return templates.has(template) && method === 'persisted';
+};
+
+export function getPersistedCodeFixAtPosition(
+  filename: string,
+  position: number,
+  info: ts.server.PluginCreateInfo
+): PersistedAction | undefined {
+  const isCallExpression = info.config.templateIsCallExpression ?? true;
+
+  if (!isCallExpression) return undefined;
+
+  let source = getSource(info, filename);
+  if (!source) return undefined;
+
+  const node = findNode(source, position);
+  if (!node) return undefined;
+
+  let callExpression: ts.Node = node;
+  // We found a node and need to check where on the path we are
+  // we expect this to look a little bit like
+  // const persistedDoc = graphql.persisted<typeof x>()
+  // When we are on the left half of this statement we bubble down
+  // looking for the correct call-expression and on the right hand
+  // we bubble up.
+  if (ts.isVariableStatement(callExpression)) {
+    callExpression =
+      callExpression.declarationList.declarations.find(declaration => {
+        return (
+          ts.isVariableDeclaration(declaration) &&
+          declaration.initializer &&
+          ts.isCallExpression(declaration.initializer)
+        );
+      }) || node;
+  } else if (ts.isVariableDeclarationList(callExpression)) {
+    callExpression =
+      callExpression.declarations.find(declaration => {
+        return (
+          ts.isVariableDeclaration(declaration) &&
+          declaration.initializer &&
+          ts.isCallExpression(declaration.initializer)
+        );
+      }) || node;
+  } else if (
+    ts.isVariableDeclaration(callExpression) &&
+    callExpression.initializer &&
+    ts.isCallExpression(callExpression.initializer)
+  ) {
+    callExpression = callExpression.initializer;
+  } else {
+    while (callExpression && !ts.isCallExpression(callExpression)) {
+      callExpression = callExpression.parent;
+    }
+  }
+
+  // We want to ensure that we found a call-expression and that it looks
+  // like "graphql.persisted", in a future iteration when the API surface
+  // is more defined we will need to use the ts.Symbol to support re-exporting
+  // this function by means of "export const peristed = graphql.persisted".
+  if (
+    !ts.isCallExpression(callExpression) ||
+    !isPersistedCall(callExpression.expression) ||
+    !callExpression.typeArguments
+  )
+    return undefined;
+
+  const [typeQuery] = callExpression.typeArguments;
+
+  if (!ts.isTypeQueryNode(typeQuery)) return undefined;
+
+  const { node: found, filename: foundFilename } =
+    getDocumentReferenceFromTypeQuery(typeQuery, filename, info);
+
+  if (!found) return undefined;
+
+  const initializer = found.initializer;
+  if (
+    !initializer ||
+    !ts.isCallExpression(initializer) ||
+    !ts.isNoSubstitutionTemplateLiteral(initializer.arguments[0])
+  )
+    return undefined;
+
+  const externalSource = getSource(info, foundFilename)!;
+  const { fragments } = findAllCallExpressions(externalSource, info);
+
+  const text = resolveTemplate(
+    initializer.arguments[0],
+    foundFilename,
+    info
+  ).combinedText;
+  const parsed = parse(text);
+  const spreads = new Set();
+  visit(parsed, {
+    FragmentSpread: node => {
+      spreads.add(node.name.value);
+    },
+  });
+
+  let resolvedText = text;
+  [...spreads].forEach(spreadName => {
+    const fragmentDefinition = fragments.find(x => x.name.value === spreadName);
+    if (!fragmentDefinition) {
+      console.warn(
+        `[GraphQLSP] could not find fragment for spread ${spreadName}!`
+      );
+      return;
+    }
+
+    resolvedText = `${resolvedText}\n\n${print(fragmentDefinition)}`;
+  });
+
+  const hash = createHash('sha256').update(text).digest('hex');
+
+  const existingHash = callExpression.arguments[0];
+  // We assume for now that this is either undefined or an existing string literal
+  if (!existingHash) {
+    // We have no persisted-identifier yet, suggest adding in a new one
+    return {
+      span: {
+        start: callExpression.arguments.pos,
+        length: 1,
+      },
+      replacement: `"sha256:${hash}")`,
+    };
+  } else if (
+    ts.isStringLiteral(existingHash) &&
+    existingHash.getText() !== `"sha256:${hash}"`
+  ) {
+    // We are out of sync, suggest replacing this with the updated hash
+    return {
+      span: {
+        start: existingHash.getStart(),
+        length: existingHash.end - existingHash.getStart(),
+      },
+      replacement: `"sha256:${hash}"`,
+    };
+  } else if (ts.isIdentifier(existingHash)) {
+    // Suggest replacing a reference with a static one
+    // this to make these easier to statically analyze
+    return {
+      span: {
+        start: existingHash.getStart(),
+        length: existingHash.end - existingHash.getStart(),
+      },
+      replacement: `"sha256:${hash}"`,
+    };
+  } else {
+    return undefined;
+  }
+}
+
+export const getDocumentReferenceFromTypeQuery = (
+  typeQuery: ts.TypeQueryNode,
+  filename: string,
+  info: ts.server.PluginCreateInfo
+): { node: ts.VariableDeclaration | null; filename: string } => {
+  // We look for the references of the generic so that we can use the document
+  // to generate the hash.
+  const references = info.languageService.getReferencesAtPosition(
+    filename,
+    typeQuery.exprName.getStart()
+  );
+
+  if (!references) return { node: null, filename };
+
+  let found: ts.VariableDeclaration | null = null;
+  let foundFilename = filename;
+  references.forEach(ref => {
+    if (found) return;
+
+    const source = getSource(info, ref.fileName);
+    if (!source) return;
+    const foundNode = findNode(source, ref.textSpan.start);
+    if (!foundNode) return;
+
+    if (ts.isVariableDeclaration(foundNode.parent)) {
+      found = foundNode.parent;
+      foundFilename = ref.fileName;
+    }
+  });
+
+  return { node: found, filename: foundFilename };
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2144,7 +2144,7 @@ packages:
     peerDependencies:
       rollup: ^2.14.0||^3.0.0||^4.0.0
       tslib: '*'
-      typescript: '>=3.7.0'
+      typescript: ^5.3.3
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -3046,7 +3046,7 @@ packages:
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
     engines: {node: '>=14'}
     peerDependencies:
-      typescript: '>=4.9.5'
+      typescript: ^5.3.3
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -5164,7 +5164,7 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       rollup: ^3.29.4 || ^4
-      typescript: ^4.5 || ^5.0
+      typescript: ^5.3.3
     dependencies:
       magic-string: 0.30.5
       rollup: 4.9.5
@@ -5664,7 +5664,7 @@ packages:
       '@swc/core': '>=1.2.50'
       '@swc/wasm': '>=1.2.50'
       '@types/node': '*'
-      typescript: '>=2.7'
+      typescript: ^5.3.3
     peerDependenciesMeta:
       '@swc/core':
         optional: true
@@ -6206,7 +6206,7 @@ packages:
     id: file:packages/graphqlsp
     name: '@0no-co/graphqlsp'
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: ^5.3.3
     dependencies:
       '@gql.tada/internal': 0.1.2(graphql@16.8.1)(typescript@5.3.3)
       graphql: 16.8.1

--- a/test/e2e/fixture-project-tada/introspection.d.ts
+++ b/test/e2e/fixture-project-tada/introspection.d.ts
@@ -422,10 +422,6 @@ export type introspection = {
       {
         "kind": "SCALAR",
         "name": "Boolean"
-      },
-      {
-        "kind": "SCALAR",
-        "name": "Any"
       }
     ],
     "directives": []


### PR DESCRIPTION
Related to https://github.com/0no-co/gql.tada/issues/77

This is an initial PR to support `graphql.persisted` as an LSP target, the goal is to provide semantic diagnostics for:

- missing type-argument
- erroneous type-argument (no reference found for instance)
- missing hash argument

Another goal is to provide a code-action to generate the `hash` associated with this invocation where we'll check whether there is a missing, or missmatched hash present and then present the user with a prompt to generate a SHA256 for the document we have found through following the TypeArgument.

We could also provide diagnostics for missmatched arguments, i.e. when the hash isn't correct compared to the hash we calculate for the referenced document but because we want to allow for ease I opted out of that.

Risks of the above choice could be that a document evolves but the user forgets to generate a new persisted-hash.

Another choice we could make is to continuously maintain a `persisted-operations.json` file while development happens so that the user can feed this to their GraphQL server during dev, otherwise we might need to insert the `definitions` so normal query-texts can be sent during development. This in turn would force our hand in providing some kind of build tool that omits these arguments, an alternative would be to tell folks to do the following

```ts
useQuery({
  query: process.env.NODE_ENV === 'development' ? document : persistedHash,
})
```

The workflow enabled by this addition would be the following

```ts
const document = graphql(`
  query Pokemon ($id: String!) {
    pokemon(id: $id) {
      id
      name
    }
  }
`)

const persistedHash = graphql.persisted<
  // facilitates inferring the types for both
  // input and output in GraphQL client invocations
  typeof document
>(
  // User can click the prompt to generate a hash or insert their own
); 
```

The benefit of using the document as a type-argument is that when the bundle is built the user will have no references to the query-text left. For some GraphQL clients this could pose an issue and force us to add the `definitions` as the second argument for instance.