### PR TITLE
chore: resolve schema from alternative rootDirectories

### DIFF
--- a/.changeset/cool-elephants-invent.md
+++ b/.changeset/cool-elephants-invent.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Add support for alternative root directories, when your tsconfig does not define GraphQLSP we'll traverse up until we find the `extends` that does and resolve the schema from there

--- a/packages/graphqlsp/package.json
+++ b/packages/graphqlsp/package.json
@@ -44,9 +44,11 @@
     "graphql": "^16.8.1",
     "graphql-language-service": "^5.2.0",
     "lru-cache": "^10.0.1",
+    "type-fest": "^4.11.1",
     "typescript": "^5.3.3"
   },
   "dependencies": {
+    "json5": "^2.2.3",
     "node-fetch": "^2.0.0"
   },
   "publishConfig": {

--- a/packages/graphqlsp/src/index.ts
+++ b/packages/graphqlsp/src/index.ts
@@ -49,7 +49,7 @@ function create(info: ts.server.PluginCreateInfo) {
   const proxy = createBasicDecorator(info);
 
   const schema = loadSchema(
-    info.project.getProjectName(),
+    info,
     config.schema,
     // TODO: either we check here for the client having a package.json
     // with gql.tada and use a default file loc or we use a config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
 
   packages/graphqlsp:
     dependencies:
+      json5:
+        specifier: ^2.2.3
+        version: 2.2.3
       node-fetch:
         specifier: ^2.0.0
         version: 2.6.7
@@ -195,6 +198,9 @@ importers:
       lru-cache:
         specifier: ^10.0.1
         version: 10.0.1
+      type-fest:
+        specifier: ^4.11.1
+        version: 4.11.1
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
@@ -4227,7 +4233,6 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
-    dev: true
 
   /jsonc-parser@3.2.0:
     resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
@@ -5710,6 +5715,11 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /type-fest@4.11.1:
+    resolution: {integrity: sha512-MFMf6VkEVZAETidGGSYW2B1MjXbGX+sWIywn2QPEaJ3j08V+MwVRHMXtf2noB8ENJaD0LIun9wh5Z6OPNf1QzQ==}
+    engines: {node: '>=16'}
+    dev: true
+
   /typed-array-length@1.0.4:
     resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}
     dependencies:
@@ -6176,6 +6186,7 @@ packages:
     resolution: {directory: packages/graphqlsp, type: directory}
     name: '@0no-co/graphqlsp'
     dependencies:
+      json5: 2.2.3
       node-fetch: 2.6.7
     transitivePeerDependencies:
       - encoding

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "plugins": [
+      {
+        "name": "@0no-co/graphqlsp",
+        "schema": "./packages/example-tada/schema.graphql",
+        "tadaOutputLocation": "./packages/example-tada/introspection.ts"
+      }
+    ],
+    "jsx": "react-jsx",
+    /* Language and Environment */
+    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    /* Modules */
+    "module": "commonjs" /* Specify what module code is generated. */,
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+    /* Type Checking */
+    "strict": true /* Enable all strict type-checking options. */,
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+  }
+}


### PR DESCRIPTION
We have seen annoyance when extending a `tsconfig` to get the correct path to resolve the schema or introspection json from. This addresses that by following the extension chain

<img width="1217" alt="A log showing that we are resolving the schema from the GraphQLSP repository root rather than the tada workspace we are in." src="https://github.com/0no-co/GraphQLSP/assets/17125876/b5a12f9d-f726-422b-8183-abeb05d6d517">

