### PR TITLE
fix(lsp): support node_modules in tsconfig resolution

### DIFF
--- a/.changeset/witty-pigs-approve.md
+++ b/.changeset/witty-pigs-approve.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': minor
+---
+
+Leverage `require.resolve` when following `tsconfig.extends` so we support `node_modules`

--- a/packages/graphqlsp/src/graphql/getSchema.ts
+++ b/packages/graphqlsp/src/graphql/getSchema.ts
@@ -147,11 +147,15 @@ const getRootDir = (
     return path.dirname(tsconfigPath);
   } else if (Array.isArray(parsed.extends)) {
     return parsed.extends.find(p => {
-      const resolved = path.resolve(path.dirname(tsconfigPath), p);
+      const resolved = require.resolve(p, {
+        paths: [path.dirname(tsconfigPath)],
+      });
       return getRootDir(info, resolved);
     });
   } else if (parsed.extends) {
-    const resolved = path.resolve(path.dirname(tsconfigPath), parsed.extends);
+    const resolved = require.resolve(parsed.extends, {
+      paths: [path.dirname(tsconfigPath)],
+    });
     return getRootDir(info, resolved);
   }
 };


### PR DESCRIPTION
Fixes https://github.com/0no-co/GraphQLSP/issues/265

This adds support for finding the extended `tsconfig` and by extension the `schema` in `node_modules`. We might need to add a `createRequire` snippet in the ESM bundle as `import.meta.resolve` still seems unstable.