### PR TITLE
feat: support first argument in graphql.persisted

### DIFF
--- a/.changeset/cuddly-needles-glow.md
+++ b/.changeset/cuddly-needles-glow.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': minor
+---
+
+Support first argument in `graphql.persisted`

--- a/.changeset/cuddly-needles-glow.md
+++ b/.changeset/cuddly-needles-glow.md
@@ -2,4 +2,4 @@
 '@0no-co/graphqlsp': minor
 ---
 
-Support first argument in `graphql.persisted`
+Support passing GraphQL documents by value to `graphql.persisted`’s second argument

--- a/packages/example-tada/src/index.tsx
+++ b/packages/example-tada/src/index.tsx
@@ -32,7 +32,7 @@ const PokemonQuery = graphql(`
   }
 `, [PokemonFields, Fields.Pokemon]);
 
-const persisted = graphql.persisted<typeof PokemonQuery>("sha256:dc31ff9637bbc77bb95dffb2ca73b0e607639b018befd06e9ad801b54483d661")
+const persisted = graphql.persisted("sha256:7a9bbe8533362e631f92af8d7f314b1589c8272f8e092da564d9ad6cd600a4eb", PokemonQuery);
 
 const Pokemons = () => {
   const [result] = useQuery({

--- a/packages/example-tada/src/index.tsx
+++ b/packages/example-tada/src/index.tsx
@@ -32,7 +32,7 @@ const PokemonQuery = graphql(`
   }
 `, [PokemonFields, Fields.Pokemon]);
 
-const persisted = graphql.persisted("sha256:7a9bbe8533362e631f92af8d7f314b1589c8272f8e092da564d9ad6cd600a4eb", PokemonQuery);
+const persisted = graphql.persisted<typeof PokemonQuery>("sha256:7a9bbe8533362e631f92af8d7f314b1589c8272f8e092da564d9ad6cd600a4eb")
 
 const Pokemons = () => {
   const [result] = useQuery({

--- a/packages/graphqlsp/src/api.ts
+++ b/packages/graphqlsp/src/api.ts
@@ -1,4 +1,7 @@
 export { getGraphQLDiagnostics } from './diagnostics';
 export { init } from './ts';
 export { findAllPersistedCallExpressions, unrollTadaFragments } from './ast';
-export { getDocumentReferenceFromTypeQuery } from './persisted';
+export {
+  getDocumentReferenceFromTypeQuery,
+  getDocumentReferenceFromDocumentNode,
+} from './persisted';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1341,7 +1341,7 @@ packages:
     resolution: {integrity: sha512-8I4Z1zxYYGK66FWdB3yIZBn3cITLPnciEgjChp3K2+Ha1e/AEBGtZv9AUlodraO/RZafDMkpFhoi+tMpluBjeg==}
     peerDependencies:
       graphql: ^16.8.1
-      typescript: ^5.3.3
+      typescript: ^5.0.0
     dependencies:
       '@0no-co/graphql.web': 1.0.6(graphql@16.8.1)
       graphql: 16.8.1
@@ -2144,7 +2144,7 @@ packages:
     peerDependencies:
       rollup: ^2.14.0||^3.0.0||^4.0.0
       tslib: '*'
-      typescript: ^5.3.3
+      typescript: '>=3.7.0'
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -3046,7 +3046,7 @@ packages:
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
     engines: {node: '>=14'}
     peerDependencies:
-      typescript: ^5.3.3
+      typescript: '>=4.9.5'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -5164,7 +5164,7 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       rollup: ^3.29.4 || ^4
-      typescript: ^5.3.3
+      typescript: ^4.5 || ^5.0
     dependencies:
       magic-string: 0.30.5
       rollup: 4.9.5
@@ -5664,7 +5664,7 @@ packages:
       '@swc/core': '>=1.2.50'
       '@swc/wasm': '>=1.2.50'
       '@types/node': '*'
-      typescript: ^5.3.3
+      typescript: '>=2.7'
     peerDependenciesMeta:
       '@swc/core':
         optional: true
@@ -6206,7 +6206,7 @@ packages:
     id: file:packages/graphqlsp
     name: '@0no-co/graphqlsp'
     peerDependencies:
-      typescript: ^5.3.3
+      typescript: ^5.0.0
     dependencies:
       '@gql.tada/internal': 0.1.2(graphql@16.8.1)(typescript@5.3.3)
       graphql: 16.8.1


### PR DESCRIPTION
We have a follow up planned where we leverage the typeChecker like https://github.com/0no-co/gql.tada/blob/main/packages/cli-utils/src/commands/cache.ts#L70-L91 to adjust the routing of `ts.identifier` and `ts.typeQuery` to the document.