### PR TITLE
chore(core): switch error message for missing-operation-name

### DIFF
--- a/.changeset/plenty-lizards-explain.md
+++ b/.changeset/plenty-lizards-explain.md
@@ -1,0 +1,5 @@
+---
+"@0no-co/graphqlsp": patch
+---
+
+switch error message for missing operation-name to not allude to typegen

--- a/packages/graphqlsp/src/diagnostics.ts
+++ b/packages/graphqlsp/src/diagnostics.ts
@@ -456,7 +456,7 @@ const runDiagnostics = (
           ) as OperationDefinitionNode;
           if (!op.name) {
             graphQLDiagnostics.push({
-              message: 'Operation needs a name for types to be generated.',
+              message: 'Operation should contain a name.',
               start: node.getStart(),
               code: MISSING_OPERATION_NAME_CODE,
               length: originalNode.getText().length,


### PR DESCRIPTION
Should we also go from Warn --> Info?

Resolves https://github.com/0no-co/GraphQLSP/issues/252