### PR TITLE
fix: Swap-write `gql.tada` output file instead of writing to it directly

### DIFF
--- a/.changeset/selfish-adults-heal.md
+++ b/.changeset/selfish-adults-heal.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Swap-write introspection file instead of overwriting it directly


### PR DESCRIPTION
This inserts the swap-writing that we do in the `gql.tada` CLI now into the GraphQLSP writing of the tada output file.