### PR TITLE
fix(diag): directive miss report with multiple documents

### DIFF
--- a/.changeset/six-chefs-hammer.md
+++ b/.changeset/six-chefs-hammer.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Fix directives being misreported due to globally declared regex maintaining state

--- a/packages/graphqlsp/src/diagnostics.ts
+++ b/packages/graphqlsp/src/diagnostics.ts
@@ -48,8 +48,6 @@ const clientDirectives = new Set([
   'inline',
 ]);
 
-const directiveRegex = /Unknown directive "@([^)]+)"/g;
-
 export const SEMANTIC_DIAGNOSTIC_CODE = 52001;
 export const MISSING_OPERATION_NAME_CODE = 52002;
 export const USING_DEPRECATED_FIELD_CODE = 52004;
@@ -385,7 +383,7 @@ const runDiagnostics = (
           if (!diag.message.includes('Unknown directive')) return true;
 
           const [message] = diag.message.split('(');
-          const matches = directiveRegex.exec(message);
+          const matches = /Unknown directive "@([^)]+)"/g.exec(message);
           if (!matches) return true;
           const directiveNmae = matches[1];
           return !clientDirectives.has(directiveNmae);


### PR DESCRIPTION
Fixes https://github.com/0no-co/gql.tada/issues/217

The global regex was aggregating state hence when two directives popped up in different documents this failed.