### PR TITLE
feat(diagnostics): validate up to date hash

### DIFF
--- a/.changeset/many-nails-wait.md
+++ b/.changeset/many-nails-wait.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Add validation step to check that the persisted-operations hash has been updated when the document changes

--- a/packages/graphqlsp/src/diagnostics.ts
+++ b/packages/graphqlsp/src/diagnostics.ts
@@ -29,7 +29,6 @@ import {
   getDocumentReferenceFromDocumentNode,
   getDocumentReferenceFromTypeQuery,
 } from './persisted';
-import { createHash } from 'node:crypto';
 
 const clientDirectives = new Set([
   'populate',

--- a/packages/graphqlsp/src/diagnostics.ts
+++ b/packages/graphqlsp/src/diagnostics.ts
@@ -252,11 +252,13 @@ export function getGraphQLDiagnostics(
 
         const hash = callExpression.arguments[0].getText().slice(1, -1);
         if (hash.startsWith('sha256:')) {
-          const upToDateHash = `sha256:${generateHashForDocument(
+          const hash = generateHashForDocument(
             info,
             initializer.arguments[0],
             foundFilename
-          )}`;
+          );
+          if (!hash) return null;
+          const upToDateHash = `sha256:${hash}`;
           if (upToDateHash !== hash) {
             return {
               category: ts.DiagnosticCategory.Warning,


### PR DESCRIPTION
During diagnostics when we see a prefix of `sha256` we can assume that we generated the hash, this means we can verify whether it's up to date. This adds a warn diagnostic for persisted-operations and warns you when the hash is up to date with the document.