### PR TITLE
patch: Increase support of harder to detect `gql.tada` API usage patterns

### DIFF
--- a/.changeset/young-phones-search.md
+++ b/.changeset/young-phones-search.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': minor
+---
+
+Expand support for `gql.tada` API. GraphQLSP will now recognize `graphql()`/`graphql.persisted()` calls regardless of variable naming and support more obscure usage patterns.

--- a/packages/graphqlsp/src/ast/checks.ts
+++ b/packages/graphqlsp/src/ast/checks.ts
@@ -1,0 +1,66 @@
+import { ts } from '../ts';
+
+export const isIIFE = (node: ts.Node): boolean =>
+  ts.isCallExpression(node) &&
+  node.arguments.length === 0 &&
+  (ts.isFunctionExpression(node.expression) ||
+    ts.isArrowFunction(node.expression)) &&
+  !node.expression.asteriskToken &&
+  !node.expression.modifiers?.length;
+
+export const isTadaGraphQLFunction = (
+  node: ts.Node,
+  checker: ts.TypeChecker | undefined
+): node is ts.LeftHandSideExpression => {
+  if (!ts.isLeftHandSideExpression(node)) return false;
+  const type = checker?.getTypeAtLocation(node);
+  // Any function that has both a `scalar` and `persisted` property
+  // is automatically considered a gql.tada graphql() function.
+  return (
+    type != null &&
+    type.getProperty('scalar') != null &&
+    type.getProperty('persisted') != null
+  );
+};
+
+export const isTadaGraphQLCall = (
+  node: ts.Node,
+  checker: ts.TypeChecker | undefined
+): node is ts.CallExpression => {
+  // We expect graphql() to be called with either a string literal
+  // or a string literal and an array of fragments
+  if (!ts.isCallExpression(node)) {
+    return false;
+  } else if (node.arguments.length < 1 || node.arguments.length > 2) {
+    return false;
+  } else if (!ts.isStringLiteralLike(node.arguments[0])) {
+    return false;
+  } else if (!/[{}]/.test(node.arguments[0].getText())) {
+    return false;
+  }
+  return checker ? isTadaGraphQLFunction(node.expression, checker) : false;
+};
+
+export const getSchemaName = (
+  node: ts.CallExpression,
+  typeChecker: ts.TypeChecker | undefined
+): string | null => {
+  if (!typeChecker) return null;
+  const expression = ts.isPropertyAccessExpression(node.expression)
+    ? node.expression.expression
+    : node.expression;
+  const type = typeChecker.getTypeAtLocation(expression);
+  if (type) {
+    const brandTypeSymbol = type.getProperty('__name');
+    if (brandTypeSymbol) {
+      const brand = typeChecker.getTypeOfSymbol(brandTypeSymbol);
+      if (brand.isUnionOrIntersection()) {
+        const found = brand.types.find(x => x.isStringLiteral());
+        return found && found.isStringLiteral() ? found.value : null;
+      } else if (brand.isStringLiteral()) {
+        return brand.value;
+      }
+    }
+  }
+  return null;
+};

--- a/packages/graphqlsp/src/ast/checks.ts
+++ b/packages/graphqlsp/src/ast/checks.ts
@@ -34,9 +34,9 @@ export const isTadaGraphQLFunction = (
 
 /** If `checker` is passed, checks if node is a gql.tada graphql() call */
 export const isTadaGraphQLCall = (
-  node: ts.Node,
+  node: ts.CallExpression,
   checker: ts.TypeChecker | undefined
-): node is ts.CallExpression => {
+): boolean => {
   // We expect graphql() to be called with either a string literal
   // or a string literal and an array of fragments
   if (!ts.isCallExpression(node)) {
@@ -44,8 +44,6 @@ export const isTadaGraphQLCall = (
   } else if (node.arguments.length < 1 || node.arguments.length > 2) {
     return false;
   } else if (!ts.isStringLiteralLike(node.arguments[0])) {
-    return false;
-  } else if (!/[{}]/.test(node.arguments[0].getText())) {
     return false;
   }
   return checker ? isTadaGraphQLFunction(node.expression, checker) : false;

--- a/packages/graphqlsp/src/ast/checks.ts
+++ b/packages/graphqlsp/src/ast/checks.ts
@@ -79,6 +79,11 @@ export const isGraphQLCall = (
   );
 };
 
+export const isGraphQLTag = (
+  node: ts.Node
+): node is ts.TaggedTemplateExpression =>
+  ts.isTaggedTemplateExpression(node) && isGraphQLFunctionIdentifier(node.tag);
+
 export const getSchemaName = (
   node: ts.CallExpression,
   typeChecker: ts.TypeChecker | undefined

--- a/packages/graphqlsp/src/ast/checks.ts
+++ b/packages/graphqlsp/src/ast/checks.ts
@@ -79,7 +79,8 @@ export const isGraphQLCall = (
 ): node is ts.CallExpression => {
   return (
     ts.isCallExpression(node) &&
-    (node.arguments.length > 1 || node.arguments.length <= 2) &&
+    node.arguments.length >= 1 &&
+    node.arguments.length <= 2 &&
     (isGraphQLFunctionIdentifier(node.expression) ||
       isTadaGraphQLCall(node, checker))
   );

--- a/packages/graphqlsp/src/ast/checks.ts
+++ b/packages/graphqlsp/src/ast/checks.ts
@@ -72,7 +72,7 @@ export const isTadaPersistedCall = (
   }
 };
 
-/** Checks if node is a gql.tada graphql.persisted() call */
+/** Checks if node is a gql.tada or regular graphql() call */
 export const isGraphQLCall = (
   node: ts.Node,
   checker: ts.TypeChecker | undefined

--- a/packages/graphqlsp/src/ast/checks.ts
+++ b/packages/graphqlsp/src/ast/checks.ts
@@ -1,6 +1,7 @@
 import { ts } from '../ts';
 import { templates } from './templates';
 
+/** Checks for an immediately-invoked function expression */
 export const isIIFE = (node: ts.Node): boolean =>
   ts.isCallExpression(node) &&
   node.arguments.length === 0 &&
@@ -9,11 +10,13 @@ export const isIIFE = (node: ts.Node): boolean =>
   !node.expression.asteriskToken &&
   !node.expression.modifiers?.length;
 
+/** Checks if node is a known identifier of graphql functions ('graphql' or 'gql') */
 export const isGraphQLFunctionIdentifier = (
   node: ts.Node
 ): node is ts.Identifier =>
   ts.isIdentifier(node) && templates.has(node.escapedText as string);
 
+/** If `checker` is passed, checks if node (as identifier/expression) is a gql.tada graphql() function */
 export const isTadaGraphQLFunction = (
   node: ts.Node,
   checker: ts.TypeChecker | undefined
@@ -29,6 +32,7 @@ export const isTadaGraphQLFunction = (
   );
 };
 
+/** If `checker` is passed, checks if node is a gql.tada graphql() call */
 export const isTadaGraphQLCall = (
   node: ts.Node,
   checker: ts.TypeChecker | undefined
@@ -47,6 +51,7 @@ export const isTadaGraphQLCall = (
   return checker ? isTadaGraphQLFunction(node.expression, checker) : false;
 };
 
+/** Checks if node is a gql.tada graphql.persisted() call */
 export const isTadaPersistedCall = (
   node: ts.Node,
   checker: ts.TypeChecker | undefined
@@ -67,6 +72,7 @@ export const isTadaPersistedCall = (
   }
 };
 
+/** Checks if node is a gql.tada graphql.persisted() call */
 export const isGraphQLCall = (
   node: ts.Node,
   checker: ts.TypeChecker | undefined
@@ -79,11 +85,13 @@ export const isGraphQLCall = (
   );
 };
 
+/** Checks if node is a gql/graphql tagged template literal */
 export const isGraphQLTag = (
   node: ts.Node
 ): node is ts.TaggedTemplateExpression =>
   ts.isTaggedTemplateExpression(node) && isGraphQLFunctionIdentifier(node.tag);
 
+/** Retrieves the `__name` branded tag from gql.tada `graphql()` or `graphql.persisted()` calls */
 export const getSchemaName = (
   node: ts.CallExpression,
   typeChecker: ts.TypeChecker | undefined

--- a/packages/graphqlsp/src/ast/index.ts
+++ b/packages/graphqlsp/src/ast/index.ts
@@ -32,14 +32,11 @@ export function findAllTaggedTemplateNodes(
   const result: Array<
     ts.TaggedTemplateExpression | ts.NoSubstitutionTemplateLiteral
   > = [];
-  // NOTE: This is not relevant for gql.tada
   function find(node: ts.Node) {
     if (
-      (ts.isTaggedTemplateExpression(node) &&
-        checks.isGraphQLFunctionIdentifier(node.tag)) ||
+      checks.isGraphQLTag(node) ||
       (ts.isNoSubstitutionTemplateLiteral(node) &&
-        ts.isTaggedTemplateExpression(node.parent) &&
-        checks.isGraphQLFunctionIdentifier(node.parent.tag))
+        checks.isGraphQLTag(node.parent))
     ) {
       result.push(node);
       return;

--- a/packages/graphqlsp/src/ast/index.ts
+++ b/packages/graphqlsp/src/ast/index.ts
@@ -91,6 +91,13 @@ function unrollFragment(
       arg2.elements.forEach(element => {
         if (ts.isIdentifier(element)) {
           fragments.push(...unrollFragment(element, info, typeChecker));
+        } else if (ts.isPropertyAccessExpression(element)) {
+          let el = element;
+          while (ts.isPropertyAccessExpression(el.expression))
+            el = el.expression;
+          if (ts.isIdentifier(el.name)) {
+            fragments.push(...unrollFragment(el.name, info, typeChecker));
+          }
         }
       });
     }
@@ -116,10 +123,7 @@ export function unrollTadaFragments(
       wip.push(...unrollFragment(element, info, typeChecker));
     } else if (ts.isPropertyAccessExpression(element)) {
       let el = element;
-      while (ts.isPropertyAccessExpression(el.expression)) {
-        el = el.expression;
-      }
-
+      while (ts.isPropertyAccessExpression(el.expression)) el = el.expression;
       if (ts.isIdentifier(el.name)) {
         wip.push(...unrollFragment(el.name, info, typeChecker));
       }

--- a/packages/graphqlsp/src/ast/index.ts
+++ b/packages/graphqlsp/src/ast/index.ts
@@ -139,14 +139,14 @@ export function findAllCallExpressions(
   shouldSearchFragments: boolean = true
 ): {
   nodes: Array<{
-    node: ts.NoSubstitutionTemplateLiteral;
+    node: ts.StringLiteralLike;
     schema: string | null;
   }>;
   fragments: Array<FragmentDefinitionNode>;
 } {
   const typeChecker = info.languageService.getProgram()?.getTypeChecker();
   const result: Array<{
-    node: ts.NoSubstitutionTemplateLiteral;
+    node: ts.StringLiteralLike;
     schema: string | null;
   }> = [];
   let fragments: Array<FragmentDefinitionNode> = [];
@@ -186,7 +186,7 @@ export function findAllCallExpressions(
       });
     }
 
-    if (arg && ts.isNoSubstitutionTemplateLiteral(arg)) {
+    if (arg && ts.isStringLiteralLike(arg)) {
       result.push({ node: arg, schema: name });
     }
   }
@@ -330,7 +330,7 @@ export function bubbleUpTemplate(node: ts.Node): ts.Node {
 
 export function bubbleUpCallExpression(node: ts.Node): ts.Node {
   while (
-    ts.isNoSubstitutionTemplateLiteral(node) ||
+    ts.isStringLiteralLike(node) ||
     ts.isToken(node) ||
     ts.isTemplateExpression(node) ||
     ts.isTemplateSpan(node)

--- a/packages/graphqlsp/src/ast/resolve.ts
+++ b/packages/graphqlsp/src/ast/resolve.ts
@@ -14,11 +14,11 @@ type TemplateResult = {
 };
 
 export function resolveTemplate(
-  node: ts.TaggedTemplateExpression | ts.NoSubstitutionTemplateLiteral,
+  node: ts.TaggedTemplateExpression | ts.StringLiteralLike,
   filename: string,
   info: ts.server.PluginCreateInfo
 ): TemplateResult {
-  if (ts.isNoSubstitutionTemplateLiteral(node)) {
+  if (ts.isStringLiteralLike(node)) {
     return { combinedText: node.getText().slice(1, -1), resolvedSpans: [] };
   }
 

--- a/packages/graphqlsp/src/ast/resolve.ts
+++ b/packages/graphqlsp/src/ast/resolve.ts
@@ -146,3 +146,20 @@ export function resolveTemplate(
 
   return { combinedText: templateText, resolvedSpans };
 }
+
+export const resolveTadaFragmentArray = (
+  node: ts.Expression | undefined
+): undefined | readonly ts.Identifier[] => {
+  if (!node) return undefined;
+  // NOTE: Remove `as T`, users may commonly use `as const` for no reason
+  while (ts.isAsExpression(node)) node = node.expression;
+  if (!ts.isArrayLiteralExpression(node)) return undefined;
+  // NOTE: Let's avoid the allocation of another array here if we can
+  if (node.elements.every(ts.isIdentifier)) return node.elements;
+  const identifiers: ts.Identifier[] = [];
+  for (let element of node.elements) {
+    while (ts.isPropertyAccessExpression(element)) element = element.expression;
+    if (ts.isIdentifier(element)) identifiers.push(element);
+  }
+  return identifiers;
+};

--- a/packages/graphqlsp/src/ast/token.ts
+++ b/packages/graphqlsp/src/ast/token.ts
@@ -11,7 +11,7 @@ export interface Token {
 }
 
 export const getToken = (
-  template: ts.TemplateLiteral,
+  template: ts.StringLiteralLike,
   cursorPosition: number
 ): Token | undefined => {
   const text = template.getText().slice(1, -1);

--- a/packages/graphqlsp/src/ast/token.ts
+++ b/packages/graphqlsp/src/ast/token.ts
@@ -11,9 +11,13 @@ export interface Token {
 }
 
 export const getToken = (
-  template: ts.StringLiteralLike,
+  template: ts.Expression,
   cursorPosition: number
 ): Token | undefined => {
+  if (!ts.isTemplateLiteral(template) && !ts.isStringLiteralLike(template)) {
+    return undefined;
+  }
+
   const text = template.getText().slice(1, -1);
   const input = text.split('\n');
   const parser = onlineParser();

--- a/packages/graphqlsp/src/autoComplete.ts
+++ b/packages/graphqlsp/src/autoComplete.ts
@@ -56,9 +56,7 @@ export function getGraphQLCompletions(
         ? schema.multi[schemaName]?.schema
         : schema.current?.schema;
 
-    const foundToken = ts.isStringLiteralLike(node.arguments[0])
-      ? getToken(node.arguments[0], cursorPosition)
-      : undefined;
+    const foundToken = getToken(node.arguments[0], cursorPosition);
     if (!schemaToUse || !foundToken) return undefined;
 
     const queryText = node.arguments[0].getText().slice(1, -1);
@@ -67,9 +65,7 @@ export function getGraphQLCompletions(
     text = `${queryText}\n${fragments.map(x => print(x)).join('\n')}`;
     cursor = new Cursor(foundToken.line, foundToken.start - 1);
   } else if (!isCallExpression && checks.isGraphQLTag(node)) {
-    const foundToken = ts.isStringLiteralLike(node.template)
-      ? getToken(node.template, cursorPosition)
-      : undefined;
+    const foundToken = getToken(node.template, cursorPosition);
     if (!foundToken || !schema.current) return undefined;
 
     const { combinedText, resolvedSpans } = resolveTemplate(

--- a/packages/graphqlsp/src/autoComplete.ts
+++ b/packages/graphqlsp/src/autoComplete.ts
@@ -15,19 +15,18 @@ import {
 import { FragmentDefinitionNode, GraphQLSchema, Kind, parse } from 'graphql';
 import { print } from '@0no-co/graphql.web';
 
+import * as checks from './ast/checks';
 import {
   bubbleUpCallExpression,
   bubbleUpTemplate,
   findNode,
   getAllFragments,
-  getSchemaName,
   getSource,
 } from './ast';
 import { Cursor } from './ast/cursor';
 import { resolveTemplate } from './ast/resolve';
 import { getToken } from './ast/token';
 import { getSuggestionsForFragmentSpread } from './graphql/getFragmentSpreadSuggestions';
-import { templates } from './ast/templates';
 import { SchemaRef } from './graphql/getSchema';
 
 export function getGraphQLCompletions(
@@ -37,7 +36,7 @@ export function getGraphQLCompletions(
   info: ts.server.PluginCreateInfo
 ): ts.WithMetadata<ts.CompletionInfo> | undefined {
   const isCallExpression = info.config.templateIsCallExpression ?? true;
-
+  const typeChecker = info.languageService.getProgram()?.getTypeChecker();
   const source = getSource(info, filename);
   if (!source) return undefined;
 
@@ -49,22 +48,17 @@ export function getGraphQLCompletions(
     : bubbleUpTemplate(node);
 
   let text, cursor, schemaToUse: GraphQLSchema | undefined;
-  if (
-    ts.isCallExpression(node) &&
-    isCallExpression &&
-    templates.has(node.expression.getText()) &&
-    node.arguments.length > 0 &&
-    ts.isNoSubstitutionTemplateLiteral(node.arguments[0])
-  ) {
-    const typeChecker = info.languageService.getProgram()?.getTypeChecker();
-    const schemaName = getSchemaName(node, typeChecker);
+  if (isCallExpression && checks.isGraphQLCall(node, typeChecker)) {
+    const schemaName = checks.getSchemaName(node, typeChecker);
 
     schemaToUse =
       schemaName && schema.multi[schemaName]
         ? schema.multi[schemaName]?.schema
         : schema.current?.schema;
 
-    const foundToken = getToken(node.arguments[0], cursorPosition);
+    const foundToken = ts.isStringLiteralLike(node.arguments[0])
+      ? getToken(node.arguments[0], cursorPosition)
+      : undefined;
     if (!schemaToUse || !foundToken) return undefined;
 
     const queryText = node.arguments[0].getText().slice(1, -1);
@@ -72,12 +66,10 @@ export function getGraphQLCompletions(
 
     text = `${queryText}\n${fragments.map(x => print(x)).join('\n')}`;
     cursor = new Cursor(foundToken.line, foundToken.start - 1);
-  } else if (ts.isTaggedTemplateExpression(node)) {
-    const { template, tag } = node;
-
-    if (!ts.isIdentifier(tag) || !templates.has(tag.text)) return undefined;
-
-    const foundToken = getToken(template, cursorPosition);
+  } else if (!isCallExpression && checks.isGraphQLTag(node)) {
+    const foundToken = ts.isStringLiteralLike(node.template)
+      ? getToken(node.template, cursorPosition)
+      : undefined;
     if (!foundToken || !schema.current) return undefined;
 
     const { combinedText, resolvedSpans } = resolveTemplate(

--- a/packages/graphqlsp/src/diagnostics.ts
+++ b/packages/graphqlsp/src/diagnostics.ts
@@ -87,7 +87,7 @@ export function getGraphQLDiagnostics(
 
   let fragments: Array<FragmentDefinitionNode> = [],
     nodes: {
-      node: ts.NoSubstitutionTemplateLiteral | ts.TaggedTemplateExpression;
+      node: ts.StringLiteralLike | ts.TaggedTemplateExpression;
       schema: string | null;
     }[];
   if (isCallExpression) {
@@ -228,7 +228,7 @@ export function getGraphQLDiagnostics(
         if (
           !initializer ||
           !ts.isCallExpression(initializer) ||
-          !ts.isNoSubstitutionTemplateLiteral(initializer.arguments[0])
+          !ts.isStringLiteralLike(initializer.arguments[0])
         ) {
           // TODO: we can make this check more stringent where we also parse and resolve
           // the accompanying template.
@@ -338,7 +338,7 @@ const runDiagnostics = (
     fragments,
   }: {
     nodes: {
-      node: ts.TaggedTemplateExpression | ts.NoSubstitutionTemplateLiteral;
+      node: ts.TaggedTemplateExpression | ts.StringLiteralLike;
       schema: string | null;
     }[];
     fragments: FragmentDefinitionNode[];

--- a/packages/graphqlsp/src/persisted.ts
+++ b/packages/graphqlsp/src/persisted.ts
@@ -106,7 +106,7 @@ export function getPersistedCodeFixAtPosition(
   if (
     !initializer ||
     !ts.isCallExpression(initializer) ||
-    !ts.isNoSubstitutionTemplateLiteral(initializer.arguments[0])
+    !ts.isStringLiteralLike(initializer.arguments[0])
   )
     return undefined;
 
@@ -155,9 +155,7 @@ export function getPersistedCodeFixAtPosition(
 
 export const generateHashForDocument = (
   info: ts.server.PluginCreateInfo,
-  templateLiteral:
-    | ts.NoSubstitutionTemplateLiteral
-    | ts.TaggedTemplateExpression,
+  templateLiteral: ts.StringLiteralLike | ts.TaggedTemplateExpression,
   foundFilename: string
 ): string | undefined => {
   const externalSource = getSource(info, foundFilename)!;

--- a/packages/graphqlsp/src/persisted.ts
+++ b/packages/graphqlsp/src/persisted.ts
@@ -2,9 +2,9 @@ import { ts } from './ts';
 
 import { createHash } from 'crypto';
 
+import * as checks from './ast/checks';
 import { findAllCallExpressions, findNode, getSource } from './ast';
 import { resolveTemplate } from './ast/resolve';
-import { templates } from './ast/templates';
 import { parse, print, visit } from '@0no-co/graphql.web';
 
 type PersistedAction = {
@@ -15,19 +15,13 @@ type PersistedAction = {
   replacement: string;
 };
 
-const isPersistedCall = (expr: ts.LeftHandSideExpression) => {
-  const expressionText = expr.getText();
-  const [template, method] = expressionText.split('.');
-  return templates.has(template) && method === 'persisted';
-};
-
 export function getPersistedCodeFixAtPosition(
   filename: string,
   position: number,
   info: ts.server.PluginCreateInfo
 ): PersistedAction | undefined {
   const isCallExpression = info.config.templateIsCallExpression ?? true;
-
+  const typeChecker = info.languageService.getProgram()?.getTypeChecker();
   if (!isCallExpression) return undefined;
 
   let source = getSource(info, filename);
@@ -77,12 +71,9 @@ export function getPersistedCodeFixAtPosition(
   // like "graphql.persisted", in a future iteration when the API surface
   // is more defined we will need to use the ts.Symbol to support re-exporting
   // this function by means of "export const peristed = graphql.persisted".
-  if (
-    (callExpression && !ts.isCallExpression(callExpression)) ||
-    !isPersistedCall(callExpression.expression) ||
-    (!callExpression.typeArguments && !callExpression.arguments[1])
-  )
+  if (!checks.isTadaPersistedCall(callExpression, typeChecker)) {
     return undefined;
+  }
 
   let foundNode,
     foundFilename = filename;
@@ -215,6 +206,7 @@ export const getDocumentReferenceFromTypeQuery = (
 
   if (!references) return { node: null, filename };
 
+  const typeChecker = info.languageService.getProgram()?.getTypeChecker();
   let found: ts.CallExpression | null = null;
   let foundFilename = filename;
   references.forEach(ref => {
@@ -228,8 +220,7 @@ export const getDocumentReferenceFromTypeQuery = (
     if (
       ts.isVariableDeclaration(foundNode.parent) &&
       foundNode.parent.initializer &&
-      ts.isCallExpression(foundNode.parent.initializer) &&
-      templates.has(foundNode.parent.initializer.expression.getText())
+      checks.isGraphQLCall(foundNode.parent.initializer, typeChecker)
     ) {
       found = foundNode.parent.initializer;
       foundFilename = ref.fileName;
@@ -254,6 +245,7 @@ export const getDocumentReferenceFromDocumentNode = (
 
     if (!references) return { node: null, filename };
 
+    const typeChecker = info.languageService.getProgram()?.getTypeChecker();
     let found: ts.CallExpression | null = null;
     let foundFilename = filename;
     references.forEach(ref => {
@@ -267,8 +259,7 @@ export const getDocumentReferenceFromDocumentNode = (
       if (
         ts.isVariableDeclaration(foundNode.parent) &&
         foundNode.parent.initializer &&
-        ts.isCallExpression(foundNode.parent.initializer) &&
-        templates.has(foundNode.parent.initializer.expression.getText())
+        checks.isGraphQLCall(foundNode.parent.initializer, typeChecker)
       ) {
         found = foundNode.parent.initializer;
         foundFilename = ref.fileName;

--- a/packages/graphqlsp/src/persisted.ts
+++ b/packages/graphqlsp/src/persisted.ts
@@ -180,7 +180,7 @@ export const generateHashForDocument = (
   [...spreads].forEach(spreadName => {
     const fragmentDefinition = fragments.find(x => x.name.value === spreadName);
     if (!fragmentDefinition) {
-      console.warn(
+      info.project.projectService.logger.info(
         `[GraphQLSP] could not find fragment for spread ${spreadName}!`
       );
       return;

--- a/packages/graphqlsp/src/quickInfo.ts
+++ b/packages/graphqlsp/src/quickInfo.ts
@@ -46,17 +46,13 @@ export function getGraphQLQuickInfo(
         ? schema.multi[schemaName]?.schema
         : schema.current?.schema;
 
-    const foundToken = ts.isStringLiteralLike(node.arguments[0])
-      ? getToken(node.arguments[0], cursorPosition)
-      : undefined;
+    const foundToken = getToken(node.arguments[0], cursorPosition);
     if (!schemaToUse || !foundToken) return undefined;
 
     text = node.arguments[0].getText();
     cursor = new Cursor(foundToken.line, foundToken.start - 1);
   } else if (!isCallExpression && checks.isGraphQLTag(node)) {
-    const foundToken = ts.isStringLiteralLike(node.template)
-      ? getToken(node.template, cursorPosition)
-      : undefined;
+    const foundToken = getToken(node.template, cursorPosition);
     if (!foundToken || !schema.current) return undefined;
 
     const { combinedText, resolvedSpans } = resolveTemplate(

--- a/packages/graphqlsp/src/quickInfo.ts
+++ b/packages/graphqlsp/src/quickInfo.ts
@@ -9,6 +9,8 @@ import {
   getSchemaName,
   getSource,
 } from './ast';
+
+import * as checks from './ast/checks';
 import { resolveTemplate } from './ast/resolve';
 import { getToken } from './ast/token';
 import { Cursor } from './ast/cursor';
@@ -22,6 +24,7 @@ export function getGraphQLQuickInfo(
   info: ts.server.PluginCreateInfo
 ): ts.QuickInfo | undefined {
   const isCallExpression = info.config.templateIsCallExpression ?? true;
+  const typeChecker = info.languageService.getProgram()?.getTypeChecker();
 
   const source = getSource(info, filename);
   if (!source) return undefined;
@@ -34,13 +37,7 @@ export function getGraphQLQuickInfo(
     : bubbleUpTemplate(node);
 
   let cursor, text, schemaToUse: GraphQLSchema | undefined;
-  if (
-    ts.isCallExpression(node) &&
-    isCallExpression &&
-    templates.has(node.expression.getText()) &&
-    node.arguments.length > 0 &&
-    ts.isNoSubstitutionTemplateLiteral(node.arguments[0])
-  ) {
+  if (isCallExpression && checks.isGraphQLCall(node, typeChecker)) {
     const typeChecker = info.languageService.getProgram()?.getTypeChecker();
     const schemaName = getSchemaName(node, typeChecker);
 
@@ -49,17 +46,17 @@ export function getGraphQLQuickInfo(
         ? schema.multi[schemaName]?.schema
         : schema.current?.schema;
 
-    const foundToken = getToken(node.arguments[0], cursorPosition);
+    const foundToken = ts.isStringLiteralLike(node.arguments[0])
+      ? getToken(node.arguments[0], cursorPosition)
+      : undefined;
     if (!schemaToUse || !foundToken) return undefined;
 
     text = node.arguments[0].getText();
     cursor = new Cursor(foundToken.line, foundToken.start - 1);
-  } else if (ts.isTaggedTemplateExpression(node)) {
-    const { template, tag } = node;
-    if (!ts.isIdentifier(tag) || !templates.has(tag.text)) return undefined;
-
-    const foundToken = getToken(template, cursorPosition);
-
+  } else if (!isCallExpression && checks.isGraphQLTag(node)) {
+    const foundToken = ts.isStringLiteralLike(node.template)
+      ? getToken(node.template, cursorPosition)
+      : undefined;
     if (!foundToken || !schema.current) return undefined;
 
     const { combinedText, resolvedSpans } = resolveTemplate(


### PR DESCRIPTION
> [!NOTE]
> Marking this as a `minor` since we already have minor changes queued up and some of the API signatures have changed slightly.

## Summary

This aims to reduce the amount of separate `templates.has` based checks and introduce a new check that can also detect `gql.tada` via the `TypeChecker` as a fallback if the name (or expression) of `graphql()` calls is non-standard.

## Set of changes

- Add `checks.ts` for all predicates
- Detect `graphql()` calls by checking `!!graphql.scalar` and `!!graphql.persisted` via the typ e checker
  - This works even if `graphql` itself is not an identifier (any expression)
  - This works even if `graphql` is renamed (more relevant now due to multi-schema support)
- Detect `graphql.persisted()` calls with the above logic
- Extract logic to detect GraphQL calls and GraphQL tagged template literals
  - Also unifies checks for `templates.has` into few reusable function
- Fix several branches where GraphQL tags were checked for even if `isCallExpression` was truthy
- Widen `NoSubstitutionTemplateLiteral` to `StringLiteralLike`
  - `graphql('...')` and `graphql("...")` will work now
  - **NOTE:** I chose not to implement a `TypeChecker` based approach here for `arguments[0]` or `arguments[1]` yet, but this could lead to some refactors which might slim down the codebase
- Prevent `getAllFragments` from expanding to check for fragments via declarations (`graphql-code-generator` code branch) even if `gql.tada` is active with new `isTadaGraphQLCall` check
- Extract logic to resolve `graphql()` fragments array literal argument
  - Expand to support `as const`
  - Consistently resolve `PropertyAccessExpression`s