### PR TITLE
patch: Mark `graphql` as a peer dependency

### DIFF
--- a/.changeset/warm-chefs-tan.md
+++ b/.changeset/warm-chefs-tan.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Update `graphql` to variably support `^15.5.0` and include future support for v17. The `graphql` package is now marked as a peer dependency in addition to a regular dependency.

--- a/packages/graphqlsp/package.json
+++ b/packages/graphqlsp/package.json
@@ -52,11 +52,12 @@
   },
   "dependencies": {
     "@gql.tada/internal": "^0.3.0",
-    "graphql": "^16.8.1",
+    "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
     "node-fetch": "^2.0.0"
   },
   "peerDependencies": {
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
   },
   "publishConfig": {
     "provenance": true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,7 +96,7 @@ importers:
     devDependencies:
       '@0no-co/graphqlsp':
         specifier: file:../graphqlsp
-        version: file:packages/graphqlsp(typescript@5.3.3)
+        version: file:packages/graphqlsp(graphql@16.8.1)(typescript@5.3.3)
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
@@ -118,7 +118,7 @@ importers:
     devDependencies:
       '@0no-co/graphqlsp':
         specifier: file:../graphqlsp
-        version: file:packages/graphqlsp(typescript@5.3.3)
+        version: file:packages/graphqlsp(graphql@16.8.1)(typescript@5.3.3)
       '@graphql-codegen/cli':
         specifier: ^5.0.0
         version: 5.0.0(@types/node@18.15.11)(graphql@16.8.1)(typescript@5.3.3)
@@ -155,7 +155,7 @@ importers:
     devDependencies:
       '@0no-co/graphqlsp':
         specifier: file:../graphqlsp
-        version: file:packages/graphqlsp(typescript@5.3.3)
+        version: file:packages/graphqlsp(graphql@16.8.1)(typescript@5.3.3)
       '@graphql-codegen/cli':
         specifier: ^5.0.0
         version: 5.0.0(@types/node@18.15.11)(graphql@16.8.1)(typescript@5.3.3)
@@ -178,7 +178,7 @@ importers:
         specifier: ^0.3.0
         version: 0.3.0(graphql@16.8.1)(typescript@5.3.3)
       graphql:
-        specifier: ^16.8.1
+        specifier: ^15.5.0 || ^16.0.0 || ^17.0.0
         version: 16.8.1
       node-fetch:
         specifier: ^2.0.0
@@ -330,10 +330,10 @@ packages:
     dependencies:
       graphql: 16.8.1
 
-  /@0no-co/graphqlsp@1.12.0(typescript@5.3.3):
-    resolution: {integrity: sha512-UkU8JETdH6jVi7O2FqTYBfCqlbfgRiAJoTD/sfmHyy8YdGC199n43S5d3qlKSYaZp/w+iihjFZYtJ9snhbfUWQ==}
+  /@0no-co/graphqlsp@1.12.1(typescript@5.3.3):
+    resolution: {integrity: sha512-KHMs1a9qXoiwA4aUKGgcsyM38SXH6ddQFwu4Hf2p8XjUOkRKHy38pd4qYM0hgA1vpkUf8WSj5GyDAbezhApfpw==}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: ^5.3.3
     dependencies:
       '@gql.tada/internal': 0.3.1(graphql@16.8.1)(typescript@5.3.3)
       graphql: 16.8.1
@@ -1401,9 +1401,9 @@ packages:
   /@gql.tada/cli-utils@1.3.0(svelte@4.2.15)(typescript@5.3.3):
     resolution: {integrity: sha512-TSf8x9zDndI+u+US1Hy/cndlHI7OvanttnfIHcm0ha6/Nnx/WcuAsprJ17ymaDVbh9CpnSz0aL8/F6IZfVBFNw==}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: ^5.3.3
     dependencies:
-      '@0no-co/graphqlsp': 1.12.0(typescript@5.3.3)
+      '@0no-co/graphqlsp': 1.12.1(typescript@5.3.3)
       '@gql.tada/internal': 0.3.1(graphql@16.8.1)(typescript@5.3.3)
       '@vue/compiler-dom': 3.4.25
       '@vue/language-core': 2.0.14(typescript@5.3.3)
@@ -1419,7 +1419,7 @@ packages:
     resolution: {integrity: sha512-blWnLfkJwR4xpCO3NIpUJ99Y/AIz1tvmZGW/ygOWZwLqzUaZ2pUxGvnmDPrqHFyVVLsJUAhP+3xHSC5qRqR5bg==}
     peerDependencies:
       graphql: ^16.8.1
-      typescript: ^5.0.0
+      typescript: ^5.3.3
     dependencies:
       '@0no-co/graphql.web': 1.0.6(graphql@16.8.1)
       graphql: 16.8.1
@@ -1430,7 +1430,7 @@ packages:
     resolution: {integrity: sha512-orrU83yh9OoeJdmn1LTOTAOYECOHXautiHLzlNuZFOTkmvSlX+W/y2TzHg28+SR/z3XDWoB6U+fIFPX/RA1qCg==}
     peerDependencies:
       graphql: ^16.8.1
-      typescript: ^5.0.0
+      typescript: ^5.3.3
     dependencies:
       '@0no-co/graphql.web': 1.0.6(graphql@16.8.1)
       graphql: 16.8.1
@@ -2316,7 +2316,7 @@ packages:
     peerDependencies:
       rollup: ^2.14.0||^3.0.0||^4.0.0
       tslib: '*'
-      typescript: '>=3.7.0'
+      typescript: ^5.3.3
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -2641,7 +2641,7 @@ packages:
   /@vue/language-core@2.0.14(typescript@5.3.3):
     resolution: {integrity: sha512-3q8mHSNcGTR7sfp2X6jZdcb4yt8AjBXAfKk0qkZIh7GAJxOnoZ10h5HToZglw4ToFvAnq+xu/Z2FFbglh9Icag==}
     peerDependencies:
-      typescript: '*'
+      typescript: ^5.3.3
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -3295,7 +3295,7 @@ packages:
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
     engines: {node: '>=14'}
     peerDependencies:
-      typescript: '>=4.9.5'
+      typescript: ^5.3.3
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -3961,7 +3961,7 @@ packages:
     resolution: {integrity: sha512-FmC0fNuSDqEzRnG0K+tSAdG9G9uvZdVhtdAGbmrqmesrGs+1YfKgbQXeKSSduhO9BKRoA3sn/XZ413tyshL6Fg==}
     hasBin: true
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: ^5.3.3
     dependencies:
       '@0no-co/graphql.web': 1.0.6(graphql@16.8.1)
       '@gql.tada/cli-utils': 1.3.0(svelte@4.2.15)(typescript@5.3.3)
@@ -5488,7 +5488,7 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       rollup: ^3.29.4 || ^4
-      typescript: ^4.5 || ^5.0
+      typescript: ^5.3.3
     dependencies:
       magic-string: 0.30.5
       rollup: 4.9.5
@@ -5907,7 +5907,7 @@ packages:
     resolution: {integrity: sha512-HAIxtk5TUHXvCRKApKfxoh1BGT85S/17lS3DvbfxRKFd+Ghr5YScqBvd+sU+p7vJFw48LNkzdFk+ooNVk3e4kA==}
     peerDependencies:
       svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
-      typescript: ^4.9.4 || ^5.0.0
+      typescript: ^5.3.3
     dependencies:
       dedent-js: 1.0.1
       pascal-case: 3.1.2
@@ -6018,7 +6018,7 @@ packages:
       '@swc/core': '>=1.2.50'
       '@swc/wasm': '>=1.2.50'
       '@types/node': '*'
-      typescript: '>=2.7'
+      typescript: ^5.3.3
     peerDependenciesMeta:
       '@swc/core':
         optional: true
@@ -6582,12 +6582,13 @@ packages:
     engines: {node: '>=12.20'}
     dev: true
 
-  file:packages/graphqlsp(typescript@5.3.3):
+  file:packages/graphqlsp(graphql@16.8.1)(typescript@5.3.3):
     resolution: {directory: packages/graphqlsp, type: directory}
     id: file:packages/graphqlsp
     name: '@0no-co/graphqlsp'
     peerDependencies:
-      typescript: ^5.0.0
+      graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
+      typescript: ^5.3.3
     dependencies:
       '@gql.tada/internal': 0.3.1(graphql@16.8.1)(typescript@5.3.3)
       graphql: 16.8.1


### PR DESCRIPTION
See https://github.com/0no-co/gql.tada/pull/282

This marks `graphql` as a peer dependency and expands its range to accept `^15.8` and `^17` (the latter for future support).

Since we're marking it as both a dependency and a peer dependency, on package managers that don't auto-install peers, no warning should in theory be issued, while still sharing dependencies.