### PR TITLE
chore: Bump `@gql.tada/internal` to `v1.0.0`

### DIFF
--- a/.changeset/weak-fans-behave.md
+++ b/.changeset/weak-fans-behave.md
@@ -2,4 +2,4 @@
 '@0no-co/graphqlsp': patch
 ---
 
-Upgrade `@gql.tada/internal` to `^0.4.0`
+Upgrade `@gql.tada/internal` to `^1.0.0`

--- a/.changeset/weak-fans-behave.md
+++ b/.changeset/weak-fans-behave.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Upgrade `@gql.tada/internal` to `^0.4.0`

--- a/packages/graphqlsp/package.json
+++ b/packages/graphqlsp/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@gql.tada/internal": "^0.3.0",
+    "@gql.tada/internal": "^0.4.0",
     "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
   },
   "peerDependencies": {

--- a/packages/graphqlsp/package.json
+++ b/packages/graphqlsp/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@gql.tada/internal": "^0.4.0",
+    "@gql.tada/internal": "^1.0.0",
     "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,8 +175,8 @@ importers:
   packages/graphqlsp:
     dependencies:
       '@gql.tada/internal':
-        specifier: ^0.3.0
-        version: 0.3.0(graphql@16.8.1)(typescript@5.3.3)
+        specifier: ^0.4.0
+        version: 0.4.0(graphql@16.8.1)(typescript@5.3.3)
       graphql:
         specifier: ^15.5.0 || ^16.0.0 || ^17.0.0
         version: 16.8.1
@@ -324,9 +324,10 @@ packages:
     dependencies:
       graphql: 16.8.1
 
-  /@0no-co/graphqlsp@1.12.1(typescript@5.3.3):
-    resolution: {integrity: sha512-KHMs1a9qXoiwA4aUKGgcsyM38SXH6ddQFwu4Hf2p8XjUOkRKHy38pd4qYM0hgA1vpkUf8WSj5GyDAbezhApfpw==}
+  /@0no-co/graphqlsp@1.12.2(graphql@16.8.1)(typescript@5.3.3):
+    resolution: {integrity: sha512-bUYuwoHuvlTIZZpt2l0furjcNMpd80T5JB4YzmOdcv+wlndHpRWeFwgnGH7qgyy986oGKxgomS0oBXjxmEMtYg==}
     peerDependencies:
+      graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
       typescript: ^5.3.3
     dependencies:
       '@gql.tada/internal': 0.3.1(graphql@16.8.1)(typescript@5.3.3)
@@ -1397,7 +1398,7 @@ packages:
     peerDependencies:
       typescript: ^5.3.3
     dependencies:
-      '@0no-co/graphqlsp': 1.12.1(typescript@5.3.3)
+      '@0no-co/graphqlsp': 1.12.2(graphql@16.8.1)(typescript@5.3.3)
       '@gql.tada/internal': 0.3.1(graphql@16.8.1)(typescript@5.3.3)
       '@vue/compiler-dom': 3.4.25
       '@vue/language-core': 2.0.14(typescript@5.3.3)
@@ -1409,8 +1410,8 @@ packages:
       - svelte
     dev: false
 
-  /@gql.tada/internal@0.3.0(graphql@16.8.1)(typescript@5.3.3):
-    resolution: {integrity: sha512-blWnLfkJwR4xpCO3NIpUJ99Y/AIz1tvmZGW/ygOWZwLqzUaZ2pUxGvnmDPrqHFyVVLsJUAhP+3xHSC5qRqR5bg==}
+  /@gql.tada/internal@0.3.1(graphql@16.8.1)(typescript@5.3.3):
+    resolution: {integrity: sha512-orrU83yh9OoeJdmn1LTOTAOYECOHXautiHLzlNuZFOTkmvSlX+W/y2TzHg28+SR/z3XDWoB6U+fIFPX/RA1qCg==}
     peerDependencies:
       graphql: ^16.8.1
       typescript: ^5.3.3
@@ -1420,10 +1421,10 @@ packages:
       typescript: 5.3.3
     dev: false
 
-  /@gql.tada/internal@0.3.1(graphql@16.8.1)(typescript@5.3.3):
-    resolution: {integrity: sha512-orrU83yh9OoeJdmn1LTOTAOYECOHXautiHLzlNuZFOTkmvSlX+W/y2TzHg28+SR/z3XDWoB6U+fIFPX/RA1qCg==}
+  /@gql.tada/internal@0.4.0(graphql@16.8.1)(typescript@5.3.3):
+    resolution: {integrity: sha512-VPJkuGcFu6dd6WPjhDK/FKcrCWtmSfb6KIFStSJc8yENLJeDkRBXm/H41lETPACHoP9N3WDh+VWgwuUAubcAVQ==}
     peerDependencies:
-      graphql: ^16.8.1
+      graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
       typescript: ^5.3.3
     dependencies:
       '@0no-co/graphql.web': 1.0.6(graphql@16.8.1)
@@ -6540,10 +6541,8 @@ packages:
       graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
       typescript: ^5.3.3
     dependencies:
-      '@gql.tada/internal': 0.3.1(graphql@16.8.1)(typescript@5.3.3)
+      '@gql.tada/internal': 0.4.0(graphql@16.8.1)(typescript@5.3.3)
       graphql: 16.8.1
       node-fetch: 2.6.7
       typescript: 5.3.3
-    transitivePeerDependencies:
-      - encoding
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,8 +175,8 @@ importers:
   packages/graphqlsp:
     dependencies:
       '@gql.tada/internal':
-        specifier: ^0.4.0
-        version: 0.4.0(graphql@16.8.1)(typescript@5.3.3)
+        specifier: ^1.0.0
+        version: 1.0.0(graphql@16.8.1)(typescript@5.3.3)
       graphql:
         specifier: ^15.5.0 || ^16.0.0 || ^17.0.0
         version: 16.8.1
@@ -1421,8 +1421,8 @@ packages:
       typescript: 5.3.3
     dev: false
 
-  /@gql.tada/internal@0.4.0(graphql@16.8.1)(typescript@5.3.3):
-    resolution: {integrity: sha512-VPJkuGcFu6dd6WPjhDK/FKcrCWtmSfb6KIFStSJc8yENLJeDkRBXm/H41lETPACHoP9N3WDh+VWgwuUAubcAVQ==}
+  /@gql.tada/internal@1.0.0(graphql@16.8.1)(typescript@5.3.3):
+    resolution: {integrity: sha512-B55aIYyZn5ewdgMqoJciPAwF5DKYX6HBabTU+ap/dpNH3EgJrLomc8Y8w+MCxCyOx+dXL9OduT6eWnVr7J7Eyg==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
       typescript: ^5.3.3
@@ -6541,7 +6541,7 @@ packages:
       graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
       typescript: ^5.3.3
     dependencies:
-      '@gql.tada/internal': 0.4.0(graphql@16.8.1)(typescript@5.3.3)
+      '@gql.tada/internal': 1.0.0(graphql@16.8.1)(typescript@5.3.3)
       graphql: 16.8.1
       node-fetch: 2.6.7
       typescript: 5.3.3


### PR DESCRIPTION
Relevant changes:
- https://github.com/0no-co/gql.tada/releases/tag/%40gql.tada%2Finternal%401.0.0
- https://github.com/0no-co/gql.tada/releases/tag/%40gql.tada%2Finternal%400.4.0