### PR TITLE
fix(lsp): nested call expressions

### DIFF
--- a/.changeset/tough-crabs-heal.md
+++ b/.changeset/tough-crabs-heal.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Support finding `graphql()` invocations within call-expressions

--- a/packages/example-tada/src/index.tsx
+++ b/packages/example-tada/src/index.tsx
@@ -2,41 +2,41 @@ import { useQuery } from 'urql';
 import { graphql } from './graphql';
 import { Fields, Pokemon, PokemonFields } from './Pokemon';
 
-const query = graphql(`
-query Po($id: ID!) {
-  pokemon(id: $id) {
-    id
-    fleeRate
-    ...Pok
-    ...pokemonFields
-    attacks {
-      special {
-        name
-        damage
+const PokemonQuery = graphql(`
+  query Po($id: ID!) {
+    pokemon(id: $id) {
+      id
+      fleeRate
+      ...Pok
+      ...pokemonFields
+      attacks {
+        special {
+          name
+          damage
+        }
       }
+      weight {
+        minimum
+        maximum
+      }
+      name
+      __typename
     }
-    weight {
-      minimum
-      maximum
+    pokemons {
+      name
+      maxCP
+      maxHP
+      types
+      fleeRate
     }
-    name
-    __typename
   }
-  pokemons {
-    name
-    maxCP
-    maxHP
-    types
-    fleeRate
-  }
-}
 `, [PokemonFields, Fields.Pokemon])
 
-// const persisted = graphql.persisted<typeof PokemonQuery>("sha256:7a9bbe8533362e631f92af8d7f314b1589c8272f8e092da564d9ad6cd600a4eb")
+const persisted = graphql.persisted<typeof PokemonQuery>("sha256:78c769ed6cfef67e17e579a2abfe4da27bd51e09ed832a88393148bcce4c5a7d")
 
 const Pokemons = () => {
   const [result] = useQuery({
-    query,
+    query: PokemonQuery,
     variables: { id: '' }
   });
   

--- a/packages/example-tada/src/index.tsx
+++ b/packages/example-tada/src/index.tsx
@@ -2,41 +2,41 @@ import { useQuery } from 'urql';
 import { graphql } from './graphql';
 import { Fields, Pokemon, PokemonFields } from './Pokemon';
 
-const PokemonQuery = graphql(`
-  query Po($id: ID!) {
-    pokemon(id: $id) {
-      id
-      fleeRate
-      ...Pok
-      ...pokemonFields
-      attacks {
-        special {
-          name
-          damage
-        }
+const query = graphql(`
+query Po($id: ID!) {
+  pokemon(id: $id) {
+    id
+    fleeRate
+    ...Pok
+    ...pokemonFields
+    attacks {
+      special {
+        name
+        damage
       }
-      weight {
-        minimum
-        maximum
-      }
-      name
-      __typename
     }
-    pokemons {
-      name
-      maxCP
-      maxHP
-      types
-      fleeRate
+    weight {
+      minimum
+      maximum
     }
+    name
+    __typename
   }
-`, [PokemonFields, Fields.Pokemon]);
+  pokemons {
+    name
+    maxCP
+    maxHP
+    types
+    fleeRate
+  }
+}
+`, [PokemonFields, Fields.Pokemon])
 
-const persisted = graphql.persisted<typeof PokemonQuery>("sha256:7a9bbe8533362e631f92af8d7f314b1589c8272f8e092da564d9ad6cd600a4eb")
+// const persisted = graphql.persisted<typeof PokemonQuery>("sha256:7a9bbe8533362e631f92af8d7f314b1589c8272f8e092da564d9ad6cd600a4eb")
 
 const Pokemons = () => {
   const [result] = useQuery({
-    query: PokemonQuery,
+    query,
     variables: { id: '' }
   });
   

--- a/packages/graphqlsp/src/ast/index.ts
+++ b/packages/graphqlsp/src/ast/index.ts
@@ -153,7 +153,7 @@ export function findAllCallExpressions(
     // Check whether we've got a `graphql()` or `gql()` call, by the
     // call expression's identifier
     if (!checks.isGraphQLCall(node, typeChecker)) {
-      return;
+      return ts.forEachChild(node, find);
     }
 
     const name = checks.getSchemaName(node, typeChecker);

--- a/packages/graphqlsp/src/ast/resolve.ts
+++ b/packages/graphqlsp/src/ast/resolve.ts
@@ -158,7 +158,7 @@ export const resolveTadaFragmentArray = (
   if (node.elements.every(ts.isIdentifier)) return node.elements;
   const identifiers: ts.Identifier[] = [];
   for (let element of node.elements) {
-    while (ts.isPropertyAccessExpression(element)) element = element.expression;
+    while (ts.isPropertyAccessExpression(element)) element = element.name;
     if (ts.isIdentifier(element)) identifiers.push(element);
   }
   return identifiers;

--- a/packages/graphqlsp/src/index.ts
+++ b/packages/graphqlsp/src/index.ts
@@ -162,7 +162,7 @@ function create(info: ts.server.PluginCreateInfo) {
         : positionOrRange.pos,
       info
     );
-    console.log('[GraphQLSP]', JSON.stringify(codefix));
+
     if (codefix) {
       return [
         {


### PR DESCRIPTION
This adds support for inline defined graphql-strings, auto-complete and quick-info always worked however diagnostics/... did not.

```js
useQuery({ query: graphql(``) })
```

This is slightly less performant as we traverse deeper but seems worth it

Fixes #316 