### PR TITLE
fix(graphqlsp): Fix resolving fragments as assignments

### DIFF
--- a/.changeset/fuzzy-donkeys-kneel.md
+++ b/.changeset/fuzzy-donkeys-kneel.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Fix fragments not being resolved when they're assigned to a property on an arbitrary identifier as an identifier.


### PR DESCRIPTION
Resolves #321

## Summary

This fixes resolving fragments from binary assignments, even if the fragment is referenced as an identifier, e.g.

```ts
x.fragment = Fragment;
x.y.fragment = Fragment;
x.y.fragment = graphql(/*...*/);
```

## Set of changes

- in `unrollFragment`
  - Detect property access expression chain in assignment
  - Detect and resolve binary expressions
  - Recurse if an identifier is found