### PR TITLE
fix(graphqlsp): Fix unchecked index accesses

### DIFF
--- a/.changeset/dry-moose-camp.md
+++ b/.changeset/dry-moose-camp.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Address potential crashes on malformed TypeScript AST input (such as missing function arguments where they were previously assumed to be passed)

--- a/packages/graphqlsp/src/ast/checks.ts
+++ b/packages/graphqlsp/src/ast/checks.ts
@@ -43,7 +43,7 @@ export const isTadaGraphQLCall = (
     return false;
   } else if (node.arguments.length < 1 || node.arguments.length > 2) {
     return false;
-  } else if (!ts.isStringLiteralLike(node.arguments[0])) {
+  } else if (!ts.isStringLiteralLike(node.arguments[0]!)) {
     return false;
   }
   return checker ? isTadaGraphQLFunction(node.expression, checker) : false;
@@ -70,11 +70,16 @@ export const isTadaPersistedCall = (
   }
 };
 
+// As per check in `isGraphQLCall()` below, enforces arguments length
+export type GraphQLCallNode = ts.CallExpression & {
+  arguments: [ts.Expression] | [ts.Expression, ts.Expression];
+};
+
 /** Checks if node is a gql.tada or regular graphql() call */
 export const isGraphQLCall = (
   node: ts.Node,
   checker: ts.TypeChecker | undefined
-): node is ts.CallExpression => {
+): node is GraphQLCallNode => {
   return (
     ts.isCallExpression(node) &&
     node.arguments.length >= 1 &&

--- a/packages/graphqlsp/src/ast/index.ts
+++ b/packages/graphqlsp/src/ast/index.ts
@@ -60,9 +60,8 @@ function unrollFragment(
     element.getStart()
   );
 
-  if (!definitions || !definitions.length) return fragments;
-
-  const [fragment] = definitions;
+  const fragment = definitions && definitions[0];
+  if (!fragment) return fragments;
 
   const externalSource = getSource(info, fragment.fileName);
   if (!externalSource) return fragments;
@@ -263,6 +262,7 @@ export function getAllFragments(
     if (
       ts.isVariableStatement(node) &&
       node.declarationList &&
+      node.declarationList.declarations[0] &&
       node.declarationList.declarations[0].name.getText() === 'documents'
     ) {
       const [declaration] = node.declarationList.declarations;

--- a/packages/graphqlsp/src/ast/resolve.ts
+++ b/packages/graphqlsp/src/ast/resolve.ts
@@ -38,9 +38,10 @@ export function resolveTemplate(
           filename,
           span.expression.getStart()
         );
-        if (!definitions || !definitions.length) return;
 
-        const def = definitions[0];
+        const def = definitions && definitions[0];
+        if (!def) return;
+
         const src = getSource(info, def.fileName);
         if (!src) return;
 

--- a/packages/graphqlsp/src/ast/token.ts
+++ b/packages/graphqlsp/src/ast/token.ts
@@ -63,7 +63,7 @@ export const getToken = (
       }
     }
 
-    cPos += input[line].length + 1;
+    cPos += input[line]!.length + 1;
   }
 
   return foundToken;

--- a/packages/graphqlsp/src/autoComplete.ts
+++ b/packages/graphqlsp/src/autoComplete.ts
@@ -299,7 +299,7 @@ function runOnlineParser(
   let stream: CharacterStream = new CharacterStream('');
 
   for (let i = 0; i < lines.length; i++) {
-    stream = new CharacterStream(lines[i]);
+    stream = new CharacterStream(lines[i]!);
     while (!stream.eol()) {
       style = parser.token(stream, state);
       const code = callback(stream, state, style, i);

--- a/packages/graphqlsp/src/checkImports.ts
+++ b/packages/graphqlsp/src/checkImports.ts
@@ -37,8 +37,8 @@ export const getColocatedFragmentNames = (
           source.fileName,
           imp.importClause.name.getStart()
         );
-        if (definitions && definitions.length) {
-          const [def] = definitions;
+        const def = definitions && definitions[0];
+        if (def) {
           if (def.fileName.includes('node_modules')) return;
 
           const externalSource = getSource(info, def.fileName);
@@ -51,22 +51,16 @@ export const getColocatedFragmentNames = (
           );
 
           const names = fragmentsForImport.map(fragment => fragment.name.value);
-          if (
-            names.length &&
-            !importSpecifierToFragments[imp.moduleSpecifier.getText()]
-          ) {
-            importSpecifierToFragments[imp.moduleSpecifier.getText()] = {
+          const key = imp.moduleSpecifier.getText();
+          let fragmentsEntry = importSpecifierToFragments[key];
+          if (names.length && fragmentsEntry) {
+            fragmentsEntry.fragments = fragmentsEntry.fragments.concat(names);
+          } else if (names.length && !fragmentsEntry) {
+            importSpecifierToFragments[key] = fragmentsEntry = {
               start: imp.moduleSpecifier.getStart(),
               length: imp.moduleSpecifier.getText().length,
               fragments: names,
             };
-          } else if (names.length) {
-            importSpecifierToFragments[
-              imp.moduleSpecifier.getText()
-            ].fragments =
-              importSpecifierToFragments[
-                imp.moduleSpecifier.getText()
-              ].fragments.concat(names);
           }
         }
       }
@@ -79,8 +73,8 @@ export const getColocatedFragmentNames = (
           source.fileName,
           imp.importClause.namedBindings.getStart()
         );
-        if (definitions && definitions.length) {
-          const [def] = definitions;
+        const def = definitions && definitions[0];
+        if (def) {
           if (def.fileName.includes('node_modules')) return;
 
           const externalSource = getSource(info, def.fileName);
@@ -92,22 +86,16 @@ export const getColocatedFragmentNames = (
             info
           );
           const names = fragmentsForImport.map(fragment => fragment.name.value);
-          if (
-            names.length &&
-            !importSpecifierToFragments[imp.moduleSpecifier.getText()]
-          ) {
-            importSpecifierToFragments[imp.moduleSpecifier.getText()] = {
+          const key = imp.moduleSpecifier.getText();
+          let fragmentsEntry = importSpecifierToFragments[key];
+          if (names.length && fragmentsEntry) {
+            fragmentsEntry.fragments = fragmentsEntry.fragments.concat(names);
+          } else if (names.length && !fragmentsEntry) {
+            importSpecifierToFragments[key] = fragmentsEntry = {
               start: imp.moduleSpecifier.getStart(),
               length: imp.moduleSpecifier.getText().length,
               fragments: names,
             };
-          } else if (names.length) {
-            importSpecifierToFragments[
-              imp.moduleSpecifier.getText()
-            ].fragments =
-              importSpecifierToFragments[
-                imp.moduleSpecifier.getText()
-              ].fragments.concat(names);
           }
         }
       } else if (
@@ -119,8 +107,8 @@ export const getColocatedFragmentNames = (
             source.fileName,
             el.getStart()
           );
-          if (definitions && definitions.length) {
-            const [def] = definitions;
+          const def = definitions && definitions[0];
+          if (def) {
             if (def.fileName.includes('node_modules')) return;
 
             const externalSource = getSource(info, def.fileName);
@@ -134,22 +122,16 @@ export const getColocatedFragmentNames = (
             const names = fragmentsForImport.map(
               fragment => fragment.name.value
             );
-            if (
-              names.length &&
-              !importSpecifierToFragments[imp.moduleSpecifier.getText()]
-            ) {
-              importSpecifierToFragments[imp.moduleSpecifier.getText()] = {
+            const key = imp.moduleSpecifier.getText();
+            let fragmentsEntry = importSpecifierToFragments[key];
+            if (names.length && fragmentsEntry) {
+              fragmentsEntry.fragments = fragmentsEntry.fragments.concat(names);
+            } else if (names.length && !fragmentsEntry) {
+              importSpecifierToFragments[key] = fragmentsEntry = {
                 start: imp.moduleSpecifier.getStart(),
                 length: imp.moduleSpecifier.getText().length,
                 fragments: names,
               };
-            } else if (names.length) {
-              importSpecifierToFragments[
-                imp.moduleSpecifier.getText()
-              ].fragments =
-                importSpecifierToFragments[
-                  imp.moduleSpecifier.getText()
-                ].fragments.concat(names);
             }
           }
         });

--- a/packages/graphqlsp/src/graphql/getFragmentSpreadSuggestions.ts
+++ b/packages/graphqlsp/src/graphql/getFragmentSpreadSuggestions.ts
@@ -120,26 +120,26 @@ function lexicalDistance(a: string, b: string): number {
   }
 
   for (j = 1; j <= bLength; j++) {
-    d[0][j] = j;
+    d[0]![j] = j;
   }
 
   for (i = 1; i <= aLength; i++) {
     for (j = 1; j <= bLength; j++) {
       const cost = a[i - 1] === b[j - 1] ? 0 : 1;
 
-      d[i][j] = Math.min(
-        d[i - 1][j] + 1,
-        d[i][j - 1] + 1,
-        d[i - 1][j - 1] + cost
+      d[i]![j] = Math.min(
+        d[i - 1]![j]! + 1,
+        d[i]![j - 1]! + 1,
+        d[i - 1]![j - 1]! + cost
       );
 
       if (i > 1 && j > 1 && a[i - 1] === b[j - 2] && a[i - 2] === b[j - 1]) {
-        d[i][j] = Math.min(d[i][j], d[i - 2][j - 2] + cost);
+        d[i]![j] = Math.min(d[i]![j]!, d[i - 2]![j - 2]! + cost);
       }
     }
   }
 
-  return d[aLength][bLength];
+  return d[aLength]![bLength]!;
 }
 
 export type AllTypeInfo = {

--- a/packages/graphqlsp/tsconfig.json
+++ b/packages/graphqlsp/tsconfig.json
@@ -8,6 +8,7 @@
     "forceConsistentCasingInFileNames": true,
     "allowJs": true,
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "skipLibCheck": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
     /* Type Checking */
     "strict": true /* Enable all strict type-checking options. */,
+    "noUncheckedIndexedAccess": true,
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   }
 }


### PR DESCRIPTION
Updates tsconfig to enable `noUncheckedIndexedAccess`.

This is because there's several cases where it's hard to keep track of where the AST could have an optional entry in an array, that was previously assumed to exist, e.g. function arguments.
This enables this option then addresses all errors to eliminate crashes where we previously didn't check arrays on the TS AST.