### PR TITLE
fix(graphqlsp): Bail out of `unrollFragment` infinite loop

### DIFF
--- a/packages/graphqlsp/src/ast/index.ts
+++ b/packages/graphqlsp/src/ast/index.ts
@@ -90,6 +90,13 @@ function unrollFragment(
   // If we found another identifier, we repeat trying to find the original
   // fragment definition
   if (ts.isIdentifier(found)) {
+    // NOTE: A gotcha of `getDefinitionAtPosition` is that when resolution fails, it points
+    // back at the original identifier (e.g. if its of the internal type `error`).
+    if (found === element) {
+      // TODO: Instead of bailing out here, we should be able to issue a diagnostic here
+      // that tells the user that resolution of a fragment has failed.
+      return fragments;
+    }
     return unrollFragment(found, info, typeChecker);
   }
 


### PR DESCRIPTION
**NOTE:** This is opened as a draft, since it's not a proper fix, but just demonstrates the issue.

Optimally, a proper fix should either:
- handle this in every call to `getDefinitionAtPosition` diagnostics,
- or; replace `getDefinitionAtPosition` in places where an alternate solution is more reliable

In specific places we should have diagnostics for these cases, since they're usually user errors (or critical errors we can't recover from).

For example, in the changed section in `unrollFragment`, we should tell the user that the fragment import is unresolveable.
There's also sections for whether a fragment is actually a GraphQL fragment call. If not, we should maybe consider adding a diagnostic to that before bailing out too.