### PR TITLE
fix(graphqlsp): Fix wrong fileType diagnostic error when introspection is disabled

### DIFF
--- a/.changeset/metal-seals-swim.md
+++ b/.changeset/metal-seals-swim.md
@@ -1,0 +1,5 @@
+---
+"@0no-co/graphqlsp": patch
+---
+
+Fix wrong fileType diagnostic error when introspection is disabled

--- a/packages/graphqlsp/src/graphql/getSchema.ts
+++ b/packages/graphqlsp/src/graphql/getSchema.ts
@@ -126,7 +126,7 @@ export const loadSchema = (
     }
 
     if (ref.current) {
-      if (ref.current.tadaOutputLocation !== undefined) {
+      if (ref.current && ref.current.tadaOutputLocation !== undefined) {
         saveTadaIntrospection(
           ref.current.introspection,
           tadaOutputLocation,

--- a/packages/graphqlsp/src/graphql/getSchema.ts
+++ b/packages/graphqlsp/src/graphql/getSchema.ts
@@ -126,12 +126,14 @@ export const loadSchema = (
     }
 
     if (ref.current) {
-      saveTadaIntrospection(
-        ref.current.introspection,
-        tadaOutputLocation,
-        tadaDisablePreprocessing,
-        logger
-      );
+      if (ref.current.tadaOutputLocation !== undefined) {
+        saveTadaIntrospection(
+          ref.current.introspection,
+          tadaOutputLocation,
+          tadaDisablePreprocessing,
+          logger
+        );
+      }
     } else if (ref.multi) {
       Object.values(ref.multi).forEach(value => {
         if (!value) return;


### PR DESCRIPTION
When using the unused field detection feature without utilising the introspection generation an error is added to the diagnostics. 

This is because the code tries to save an introspection file even when the provided output path is undefined.

I have made this small fix to stop the plugin from trying to save an introspection file when the output path is undefined.

This is relevant to me, because in the Project i am working on we use other ways of generating typescript files but want to use the unused field detection and autocompletion. This works fine in the IDE, but when reading the diagnostics of typescript in the CLI to create a pipeline that ensures every field is used, we also get an error about an unsupported file type for the introspection output path (Thrown in saveTadaIntrospection).

I just want to add that we very much enjoy the features this package provides, so thank you for your work!
Have a great day!
Looking forward to your feedback,
Leo
