### PR TITLE
fix(graphqlsp): Fix infinite loop conditions when resolving fragments

### DIFF
--- a/.changeset/fuzzy-scissors-appear.md
+++ b/.changeset/fuzzy-scissors-appear.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Prevent resolution loop when resolving GraphQL fragments

--- a/packages/graphqlsp/src/ast/index.ts
+++ b/packages/graphqlsp/src/ast/index.ts
@@ -56,8 +56,12 @@ function unrollFragment(
 ): Array<FragmentDefinitionNode> {
   const fragments: FragmentDefinitionNode[] = [];
   const elements: ts.Identifier[] = [element];
+  const seen = new WeakSet<ts.Identifier>();
 
   const _unrollElement = (element: ts.Identifier): void => {
+    if (seen.has(element)) return;
+    seen.add(element);
+
     const definitions = info.languageService.getDefinitionAtPosition(
       element.getSourceFile().fileName,
       element.getStart()


### PR DESCRIPTION
Resolve https://github.com/0no-co/gql.tada/issues/374

## Summary

Two loops can occur when resolving fragments:
- Loops between mutual fragments
- Loops when resolving an identifier

The first one is mostly to prevent crashes, but is already invalid and will lead to invalid behaviour. This occurs when two references reference each other. If TypeScript happens to still be able to resolve this condition, then we'd infinitely jump between the two fragments. This is easily prevented by keeping a `WeakSet` of `Identifier`s.

The second condition — which is more common in valid code — happens in scenarios when resolving an identifier leads back to this same identifier. I'm not 100% sure when this happens, but it's easily prevented.

I separated the fragment resolution into two parts to make the issue stand out more as well.

## Set of changes

- Extract GraphQL Node resolution from `unrollFragment`
- Prevent resolving the same identifier twice in a row
- Prevent `unrollFragment` from recursing
- Prevent `unrollFragment` from processing the same identifier twice