### PR TITLE
fix: Strip the unmask directive

### DIFF
--- a/.changeset/fluffy-rabbits-shake.md
+++ b/.changeset/fluffy-rabbits-shake.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Strip our internal `@_unmask` directive from fragment-definitions when creating hashes for persisted-operations


### PR DESCRIPTION
Resolves https://github.com/0no-co/gql.tada/issues/387
Relates to https://github.com/0no-co/gql.tada/pull/388

## Summary

This guarantees correctness as the API won't know about this directive
