### PR TITLE
fix(field-usage): Crawl chained scopes

### DIFF
--- a/.changeset/beige-queens-worry.md
+++ b/.changeset/beige-queens-worry.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Handle chained expressions while crawling scopes

--- a/test/e2e/fixture-project-tada/introspection.d.ts
+++ b/test/e2e/fixture-project-tada/introspection.d.ts
@@ -31,3 +31,9 @@ export type introspection = {
 };
 
 import * as gqlTada from 'gql.tada';
+
+declare module 'gql.tada' {
+  interface setupSchema {
+    introspection: introspection;
+  }
+}

--- a/test/e2e/fixture-project-unused-fields/fixtures/chained-usage.ts
+++ b/test/e2e/fixture-project-unused-fields/fixtures/chained-usage.ts
@@ -1,0 +1,37 @@
+import { useQuery } from 'urql';
+import { useMemo } from 'react';
+import { graphql } from './gql';
+
+const PokemonsQuery = graphql(
+  `
+    query Pok {
+      pokemons {
+        name
+        maxCP
+        maxHP
+        fleeRate
+      }
+    }
+  `
+);
+
+const Pokemons = () => {
+  const [result] = useQuery({
+    query: PokemonsQuery,
+  });
+
+  const results = useMemo(() => {
+    if (!result.data?.pokemons) return [];
+    return (
+      result.data.pokemons
+        .filter(i => i?.name === 'Pikachu')
+        .map(p => ({
+          x: p?.maxCP,
+          y: p?.maxHP,
+        })) ?? []
+    );
+  }, [result.data?.pokemons]);
+
+  // @ts-ignore
+  return results;
+};

--- a/test/e2e/fixture-project-unused-fields/fixtures/gql/gql.ts
+++ b/test/e2e/fixture-project-unused-fields/fixtures/gql/gql.ts
@@ -17,6 +17,8 @@ const documents = {
     types.PokemonFieldsFragmentDoc,
   '\n  query Po($id: ID!) {\n    pokemon(id: $id) {\n      id\n      fleeRate\n      ...pokemonFields\n      attacks {\n        special {\n          name\n          damage\n        }\n      }\n      weight {\n        minimum\n        maximum\n      }\n      name\n      __typename\n    }\n  }\n':
     types.PoDocument,
+  '\n    query Pok {\n      pokemons {\n        name\n        maxCP\n        maxHP\n        fleeRate\n      }\n    }\n  ':
+    types.PokDocument,
 };
 
 /**
@@ -45,6 +47,12 @@ export function graphql(
 export function graphql(
   source: '\n  query Po($id: ID!) {\n    pokemon(id: $id) {\n      id\n      fleeRate\n      ...pokemonFields\n      attacks {\n        special {\n          name\n          damage\n        }\n      }\n      weight {\n        minimum\n        maximum\n      }\n      name\n      __typename\n    }\n  }\n'
 ): (typeof documents)['\n  query Po($id: ID!) {\n    pokemon(id: $id) {\n      id\n      fleeRate\n      ...pokemonFields\n      attacks {\n        special {\n          name\n          damage\n        }\n      }\n      weight {\n        minimum\n        maximum\n      }\n      name\n      __typename\n    }\n  }\n'];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n    query Pok {\n      pokemons {\n        name\n        maxCP\n        maxHP\n        fleeRate\n      }\n    }\n  '
+): (typeof documents)['\n    query Pok {\n      pokemons {\n        name\n        maxCP\n        maxHP\n        fleeRate\n      }\n    }\n  '];
 
 export function graphql(source: string) {
   return (documents as any)[source] ?? {};

--- a/test/e2e/fixture-project-unused-fields/fixtures/gql/graphql.ts
+++ b/test/e2e/fixture-project-unused-fields/fixtures/gql/graphql.ts
@@ -162,6 +162,19 @@ export type PoQuery = {
     | null;
 };
 
+export type PokQueryVariables = Exact<{ [key: string]: never }>;
+
+export type PokQuery = {
+  __typename?: 'Query';
+  pokemons?: Array<{
+    __typename?: 'Pokemon';
+    name: string;
+    maxCP?: number | null;
+    maxHP?: number | null;
+    fleeRate?: number | null;
+  } | null> | null;
+};
+
 export const PokemonFieldsFragmentDoc = {
   kind: 'Document',
   definitions: [
@@ -338,3 +351,31 @@ export const PoDocument = {
     },
   ],
 } as unknown as DocumentNode<PoQuery, PoQueryVariables>;
+export const PokDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: { kind: 'Name', value: 'Pok' },
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'pokemons' },
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: 'name' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'maxCP' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'maxHP' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'fleeRate' } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<PokQuery, PokQueryVariables>;


### PR DESCRIPTION
Fixes https://github.com/0no-co/GraphQLSP/issues/353

The AST when we are dealing with nested scopes looks like the following

```
VariableDeclaration --> CallExpression --> PropertyAccessExpression --> CallExpression --> PropertyAccessExpression
```

The solution we implement here will keep looking for nested `CallExpression` and traverse them.

Note that I haven't been able to test this yet and that this is mainly a conceptual solution, I'm intending to test this out before merging 😅 