### PR TITLE
Allow specifying clientDirectives option

### DIFF
--- a/.changeset/upset-hats-remain.md
+++ b/.changeset/upset-hats-remain.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': minor
+---
+
+Allow supplying a custom `clientDirectives` which will be mixed in with the base client directives

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ when on a TypeScript file or adding a file like [this](https://github.com/0no-co
 - `tadaOutputLocation` when using `gql.tada` this can be convenient as it automatically generates
   an `introspection.ts` file for you, just give it the directory to output to and you're done
 - `tadaDisablePreprocessing` this setting disables the optimisation of `tadaOutput` to a pre-processed TypeScript type, this is off by default.
+- `clientDirectives` this setting allows you to specify additional `clientDirectives` which won't be seen as a missing schema-directive.
 
 ## Tracking unused fields
 

--- a/packages/graphqlsp/README.md
+++ b/packages/graphqlsp/README.md
@@ -73,6 +73,7 @@ when on a TypeScript file or adding a file like [this](https://github.com/0no-co
   from usage tracking, so when they are unused in the component but used in i.e. the normalised cache you
   won't get annoying warnings. (default `id`, `_id` and `__typename`, example: ['slug'])
 - `tadaDisablePreprocessing` this setting disables the optimisation of `tadaOutput` to a pre-processed TypeScript type, this is off by default.
+- `clientDirectives` this setting allows you to specify additional `clientDirectives` which won't be seen as a missing schema-directive.
 
 ## Tracking unused fields
 

--- a/packages/graphqlsp/src/diagnostics.ts
+++ b/packages/graphqlsp/src/diagnostics.ts
@@ -31,9 +31,10 @@ import {
 } from './persisted';
 import { SchemaRef } from './graphql/getSchema';
 
-const clientDirectives = new Set([
+const BASE_CLIENT_DIRECTIVES = new Set([
   'populate',
   'client',
+  'unmask',
   '_unmask',
   '_optional',
   '_relayPagination',
@@ -418,6 +419,11 @@ const runDiagnostics = (
       if (!schemaToUse) {
         return undefined;
       }
+
+      const clientDirectives = new Set([
+        ...BASE_CLIENT_DIRECTIVES,
+        ...(info.config.clientDirectives || []),
+      ]);
 
       const graphQLDiagnostics = getDiagnostics(
         text,

--- a/packages/graphqlsp/src/index.ts
+++ b/packages/graphqlsp/src/index.ts
@@ -30,6 +30,7 @@ interface Config {
   templateIsCallExpression?: boolean;
   shouldCheckForColocatedFragments?: boolean;
   template?: string;
+  clientDirectives?: string[];
   trackFieldUsage?: boolean;
   tadaOutputLocation?: string;
 }


### PR DESCRIPTION
Resolves https://github.com/0no-co/GraphQLSP/issues/367

In `urql` you can create custom-directives that have their own behaviour, to support this we allow the user to specify their own `clientDirectives`