### PR TITLE
Forward all arguments in getQuickInfoAtPosition proxy

### DIFF
--- a/.changeset/fix-expandable-hovers.md
+++ b/.changeset/fix-expandable-hovers.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Forward all arguments from the `getQuickInfoAtPosition` proxy to the underlying TypeScript language service, so that the `verbosityLevel` argument (added in TypeScript 5.9 for expandable hovers) is no longer stripped when GraphQLSP delegates back to TypeScript.

--- a/packages/graphqlsp/src/index.ts
+++ b/packages/graphqlsp/src/index.ts
@@ -185,7 +185,10 @@ function create(info: ts.server.PluginCreateInfo) {
     }
   };
 
-  proxy.getQuickInfoAtPosition = (filename: string, cursorPosition: number) => {
+  proxy.getQuickInfoAtPosition = (
+    ...args: Parameters<ts.LanguageService['getQuickInfoAtPosition']>
+  ) => {
+    const [filename, cursorPosition] = args;
     const quickInfo = getGraphQLQuickInfo(
       filename,
       cursorPosition,
@@ -195,10 +198,9 @@ function create(info: ts.server.PluginCreateInfo) {
 
     if (quickInfo) return quickInfo;
 
-    return info.languageService.getQuickInfoAtPosition(
-      filename,
-      cursorPosition
-    );
+    // Forward all arguments (including `verbosityLevel` for expandable
+    // hovers, added in TS 5.9) so we don't break the underlying feature.
+    return info.languageService.getQuickInfoAtPosition(...args);
   };
 
   logger('proxy: ' + JSON.stringify(proxy));


### PR DESCRIPTION
## Summary
Updated the `getQuickInfoAtPosition` proxy method to forward all arguments to the underlying TypeScript language service, rather than only passing the first two parameters. This ensures that newer TypeScript features like the `verbosityLevel` argument (added in TypeScript 5.9 for expandable hovers) are properly supported.

Fixes https://github.com/0no-co/gql.tada/issues/518