### PR TITLE
fix: resolve leaf identifier for nested property access in unrollTadaFragments

### DIFF
--- a/.changeset/eighty-wombats-live.md
+++ b/.changeset/eighty-wombats-live.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Fix multi-level property accessor when resolving fragments in gql.tada generate-persisted

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     }
   },
   "devDependencies": {
+    "@0no-co/graphql.web": "^1.0.4",
     "@actions/core": "^1.10.0",
     "@actions/github": "^5.1.1",
     "@babel/plugin-transform-block-scoping": "^7.23.4",

--- a/packages/graphqlsp/src/ast/index.ts
+++ b/packages/graphqlsp/src/ast/index.ts
@@ -116,10 +116,12 @@ export function unrollTadaFragments(
     if (ts.isIdentifier(element)) {
       wip.push(...unrollFragment(element, info, typeChecker));
     } else if (ts.isPropertyAccessExpression(element)) {
-      let el = element;
-      while (ts.isPropertyAccessExpression(el.expression)) el = el.expression;
-      if (ts.isIdentifier(el.name)) {
-        wip.push(...unrollFragment(el.name, info, typeChecker));
+      // PropertyAccessExpression is left-recursive in the AST (`a.b.c`
+      // parses as `PropertyAccess(PropertyAccess(a, b), c)`), so
+      // `element.name` is always the leaf identifier — the property we
+      // actually want to resolve — regardless of chain depth.
+      if (ts.isIdentifier(element.name)) {
+        wip.push(...unrollFragment(element.name, info, typeChecker));
       }
     }
   });

--- a/packages/graphqlsp/src/ast/index.ts
+++ b/packages/graphqlsp/src/ast/index.ts
@@ -116,10 +116,6 @@ export function unrollTadaFragments(
     if (ts.isIdentifier(element)) {
       wip.push(...unrollFragment(element, info, typeChecker));
     } else if (ts.isPropertyAccessExpression(element)) {
-      // PropertyAccessExpression is left-recursive in the AST (`a.b.c`
-      // parses as `PropertyAccess(PropertyAccess(a, b), c)`), so
-      // `element.name` is always the leaf identifier — the property we
-      // actually want to resolve — regardless of chain depth.
       if (ts.isIdentifier(element.name)) {
         wip.push(...unrollFragment(element.name, info, typeChecker));
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
 
   .:
     devDependencies:
+      '@0no-co/graphql.web':
+        specifier: ^1.0.4
+        version: 1.2.0(graphql@16.8.1)
       '@actions/core':
         specifier: ^1.10.0
         version: 1.10.0
@@ -312,6 +315,7 @@ packages:
         optional: true
     dependencies:
       graphql: 16.8.1
+    dev: true
 
   /@0no-co/graphql.web@1.2.0(graphql@16.8.1):
     resolution: {integrity: sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw==}
@@ -323,11 +327,11 @@ packages:
     dependencies:
       graphql: 16.8.1
 
-  /@0no-co/graphqlsp@1.15.0(graphql@16.8.1)(typescript@5.3.3):
-    resolution: {integrity: sha512-SReJAGmOeXrHGod+9Odqrz4s43liK0b2DFUetb/jmYvxFpWmeNfFYo0seCh0jz8vG3p1pnYMav0+Tm7XwWtOJw==}
+  /@0no-co/graphqlsp@1.15.4(graphql@16.8.1)(typescript@5.3.3):
+    resolution: {integrity: sha512-Nt1DVHcZ08lKRKwhiU0amXH77fSdrO6DzyjLE0DkCxfbM/N1SAs32d76y1xtCzM5H9eT0iDS7SdksgRXWJu05g==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
-      typescript: ^5.0.0
+      typescript: ^5.0.0 || ^6.0.0
     dependencies:
       '@gql.tada/internal': 1.0.0(graphql@16.8.1)(typescript@5.3.3)
       graphql: 16.8.1
@@ -1092,7 +1096,7 @@ packages:
     peerDependencies:
       typescript: ^5.0.0
     dependencies:
-      '@0no-co/graphqlsp': 1.15.0(graphql@16.8.1)(typescript@5.3.3)
+      '@0no-co/graphqlsp': 1.15.4(graphql@16.8.1)(typescript@5.3.3)
       '@gql.tada/internal': 0.3.1(graphql@16.8.1)(typescript@5.3.3)
       '@vue/compiler-dom': 3.5.24
       '@vue/language-core': 2.2.12(typescript@5.3.3)
@@ -2533,7 +2537,7 @@ packages:
   /@urql/core@4.0.4(graphql@16.8.1):
     resolution: {integrity: sha512-r1rB/VMVpCnfnMTTzCAs+HY+UqOHUgpZ+GimLtU4DCTP3C78DK+m4qr36M7KKleggrKgcpcC1TE8eFEVcKzfSQ==}
     dependencies:
-      '@0no-co/graphql.web': 1.0.4(graphql@16.8.1)
+      '@0no-co/graphql.web': 1.2.0(graphql@16.8.1)
       wonka: 6.3.5
     transitivePeerDependencies:
       - graphql
@@ -2542,7 +2546,7 @@ packages:
   /@urql/core@4.3.0(graphql@16.8.1):
     resolution: {integrity: sha512-wT+FeL8DG4x5o6RfHEnONNFVDM3616ouzATMYUClB6CB+iIu2mwfBKd7xSUxYOZmwtxna5/hDRQdMl3nbQZlnw==}
     dependencies:
-      '@0no-co/graphql.web': 1.0.4(graphql@16.8.1)
+      '@0no-co/graphql.web': 1.2.0(graphql@16.8.1)
       wonka: 6.3.5
     transitivePeerDependencies:
       - graphql
@@ -5668,10 +5672,10 @@ packages:
     resolution: {directory: packages/graphqlsp, type: directory}
     id: file:packages/graphqlsp
     name: '@0no-co/graphqlsp'
-    version: 1.15.0
+    version: 1.15.4
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
-      typescript: ^5.0.0
+      typescript: ^5.0.0 || ^6.0.0
     dependencies:
       '@gql.tada/internal': 1.0.0(graphql@16.8.1)(typescript@5.3.3)
       graphql: 16.8.1

--- a/test/e2e/fixture-project-tada/fixtures/persisted-nested-fragments.ts
+++ b/test/e2e/fixture-project-tada/fixtures/persisted-nested-fragments.ts
@@ -1,0 +1,33 @@
+import { graphql } from './graphql';
+
+// Fragments registered under a nested object on a component
+// (`Component.fragments.<name>`). The persisted hash must reflect the
+// fragment text — earlier versions of `unrollTadaFragments` resolved
+// the wrong identifier in this two-level access chain and silently
+// omitted the fragment from the hash input.
+function Attacks() {}
+Attacks.fragments = {
+  fast: graphql(`
+    fragment PokemonAttacks on Pokemon {
+      attacks {
+        fast {
+          name
+          damage
+        }
+      }
+    }
+  `),
+};
+
+const Query = graphql(
+  `
+    query GetPokemonNested {
+      pokemon(id: "x") {
+        ...PokemonAttacks
+      }
+    }
+  `,
+  [Attacks.fragments.fast]
+);
+
+graphql.persisted('sha256:incorrect', Query);

--- a/test/e2e/persisted-tada.test.ts
+++ b/test/e2e/persisted-tada.test.ts
@@ -1,0 +1,154 @@
+import { parse, print } from '@0no-co/graphql.web';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { TSServer } from './server';
+import path from 'node:path';
+import fs from 'node:fs';
+import url from 'node:url';
+import ts from 'typescript/lib/tsserverlibrary';
+import { createHash } from 'node:crypto';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+const projectPath = path.resolve(__dirname, 'fixture-project-tada');
+
+// `MISSMATCH_HASH_TO_DOCUMENT` from packages/graphqlsp/src/diagnostics.ts
+const MISSMATCH_HASH_TO_DOCUMENT = 520103;
+
+describe('Persisted operation hash + tada', () => {
+  const outfile = path.join(projectPath, 'persisted-nested-fragments.ts');
+
+  let server: TSServer;
+  beforeAll(() => {
+    server = new TSServer(projectPath, { debugLog: false });
+
+    server.sendCommand('open', {
+      file: outfile,
+      fileContent: '// empty',
+      scriptKindName: 'TS',
+    } satisfies ts.server.protocol.OpenRequestArgs);
+
+    server.sendCommand('updateOpen', {
+      openFiles: [
+        {
+          file: outfile,
+          fileContent: fs.readFileSync(
+            path.join(projectPath, 'fixtures/persisted-nested-fragments.ts'),
+            'utf-8'
+          ),
+        },
+      ],
+    } satisfies ts.server.protocol.UpdateOpenRequestArgs);
+
+    server.sendCommand('saveto', {
+      file: outfile,
+      tmpfile: outfile,
+    } satisfies ts.server.protocol.SavetoRequestArgs);
+  });
+
+  afterAll(() => {
+    try {
+      fs.unlinkSync(outfile);
+    } catch {}
+  });
+
+  it('reports a hash mismatch when a fragment referenced via nested property access (Component.fragments.<name>) is included in the document', async () => {
+    await server.waitForResponse(
+      e => e.type === 'event' && e.event === 'semanticDiag'
+    );
+    const responses = server.responses.filter(
+      resp =>
+        resp.type === 'event' &&
+        resp.event === 'semanticDiag' &&
+        resp.body?.file === outfile
+    );
+    const lastDiagnostics: any[] =
+      responses[responses.length - 1]?.body?.diagnostics ?? [];
+
+    const hashMismatch = lastDiagnostics.find(
+      d => d.code === MISSMATCH_HASH_TO_DOCUMENT
+    );
+    expect(
+      hashMismatch,
+      `expected hash-mismatch diagnostic, got: ${JSON.stringify(
+        lastDiagnostics,
+        null,
+        2
+      )}`
+    ).toBeDefined();
+    expect(hashMismatch).toMatchInlineSnapshot(`
+      {
+        "category": "warning",
+        "code": 520103,
+        "end": {
+          "line": 33,
+          "offset": 44,
+        },
+        "start": {
+          "line": 33,
+          "offset": 19,
+        },
+        "text": "The persisted document's hash is outdated",
+      }
+    `);
+
+    // Also verify the "Insert document-id" refactor proposes the
+    // correct hash — i.e. the digest of the query *with* the fragment.
+    // If the bug regresses, the proposed hash flips to the query-only
+    // value below.
+    server.send({
+      type: 'request',
+      command: 'getEditsForRefactor',
+      arguments: {
+        file: outfile,
+        startLine: 33,
+        startOffset: 9,
+        endLine: 33,
+        endOffset: 9,
+        refactor: 'GraphQL',
+        action: 'Insert document-id',
+      },
+    });
+    await server.waitForResponse(
+      response =>
+        response.type === 'response' &&
+        response.command === 'getEditsForRefactor'
+    );
+    const refactorResponse = server.responses
+      .reverse()
+      .find(
+        resp =>
+          resp.type === 'response' && resp.command === 'getEditsForRefactor'
+      );
+    const replacement: string =
+      refactorResponse!.body!.edits![0]!.textChanges![0]!.newText!.replaceAll(
+        /"/g,
+        ''
+      );
+    expect(replacement).toMatchInlineSnapshot(
+      '"sha256:2cb43b8f11334b38ac959dd27b697b6a66d9cf0891929f138b2148c6c7ff33ca"'
+    );
+
+    const expectedHashedContent = print(
+      parse(`
+    query GetPokemonNested {
+      pokemon(id: "x") {
+        ...PokemonAttacks
+      }
+    }
+    fragment PokemonAttacks on Pokemon {
+      attacks {
+        fast {
+          name
+          damage
+        }
+      }
+    }
+    `)
+    );
+
+    expect(replacement).toEqual(
+      'sha256:' +
+        createHash('sha256').update(expectedHashedContent).digest('hex')
+    );
+  }, 30000);
+});


### PR DESCRIPTION
## Summary

resolves #390

`unrollTadaFragments` silently dropped fragments referenced via two-level property access (e.g. `Component.fragments.<name>`). The handler for `PropertyAccessExpression` walked the chain non-recursively and ended up resolving the middle identifier (`fragments`) instead of the leaf, so the fragment never made it into the persisted-document body.

`PropertyAccessExpression` is left-recursive in the AST — `a.b.c` parses as `PropertyAccess(PropertyAccess(a, b), c)` — so the leaf identifier we actually want is just `element.name`. Using it directly handles arbitrary chain depth.

## Repro

```ts
function Attacks() {}
Attacks.fragments = {
  fast: graphql(`
    fragment PokemonAttacks on Pokemon {
      attacks { fast { name damage } }
    }
  `),
};

const Query = graphql(
  `query GetPokemonNested { pokemon(id: "x") { ...PokemonAttacks } }`,
  [Attacks.fragments.fast]
);

graphql.persisted('sha256:incorrect', Query);
```

`gql.tada generate-persisted` (which consumes `unrollTadaFragments` via `@0no-co/graphqlsp/api`) emitted the manifest body without the `PokemonAttacks` fragment definition, so downstream hash checks computed a different digest than the plugin had stored.

## Test

Added `test/e2e/persisted-tada.test.ts` plus the fixture `fixture-project-tada/fixtures/persisted-nested-fragments.ts`. The fixture references its fragment via `Attacks.fragments.fast` and uses an obviously wrong placeholder hash (`'sha256:incorrect'`). The test drives the TSServer against the fixture and asserts:

1. The plugin emits a `MISSMATCH_HASH_TO_DOCUMENT` (520103) diagnostic on the `graphql.persisted(...)` call.
2. The "Insert document-id" refactor's suggested replacement is the SHA-256 of `print(parse(query + fragment))` — built in-test from the literal query and fragment source — confirming the plugin's computed digest reflects the whole document, fragment included.

If the bug regresses, `unrollTadaFragments` drops the fragment and the plugin's suggested hash collapses to the query-only digest, failing assertion (2).