### PR TITLE
Reduce type-checker work in findAllCallExpressions

### DIFF
--- a/.changeset/quick-spies-shave.md
+++ b/.changeset/quick-spies-shave.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': minor
+---
+
+Reduce type-checker work in `findAllCallExpressions`. The gql.tada function detection and schema-name lookups are now memoized per callee, so ordinary calls with a string-literal first argument (e.g. `t('key')`, `it('name', fn)`) no longer trigger a type probe per call site. Fragment unrolling is deduplicated for repeated references to the same fragment, and the third argument of `findAllCallExpressions` now also accepts an options object (`{ searchExternal?: boolean; collectFragments?: boolean }`), where `collectFragments: false` skips fragment collection entirely for callers that only consume `nodes`.

--- a/packages/graphqlsp/src/api.ts
+++ b/packages/graphqlsp/src/api.ts
@@ -7,6 +7,8 @@ export {
   unrollTadaFragments,
 } from './ast';
 
+export type { FindAllCallExpressionsOptions } from './ast';
+
 export {
   getDocumentReferenceFromTypeQuery,
   getDocumentReferenceFromDocumentNode,

--- a/packages/graphqlsp/src/ast/checks.ts
+++ b/packages/graphqlsp/src/ast/checks.ts
@@ -16,20 +16,52 @@ export const isGraphQLFunctionIdentifier = (
 ): node is ts.Identifier =>
   ts.isIdentifier(node) && templates.has(node.escapedText as string);
 
+// The verdicts of the type probes below never change for a given function
+// within one program, but are requested once per call site. Caching them per
+// symbol turns the type checker work from one probe per call site into one
+// per distinct callee. Keying by checker makes invalidation automatic, since
+// a new program comes with a new checker.
+const tadaFunctionCache = new WeakMap<
+  ts.TypeChecker,
+  WeakMap<ts.Symbol, boolean>
+>();
+
+const schemaNameCache = new WeakMap<
+  ts.TypeChecker,
+  WeakMap<ts.Symbol, string | null>
+>();
+
+const getCached = <T>(
+  caches: WeakMap<ts.TypeChecker, WeakMap<ts.Symbol, T>>,
+  checker: ts.TypeChecker,
+  node: ts.Node,
+  compute: () => T
+): T => {
+  const symbol = checker.getSymbolAtLocation(node);
+  if (!symbol) return compute();
+  let cache = caches.get(checker);
+  if (!cache) caches.set(checker, (cache = new WeakMap()));
+  let result = cache.get(symbol);
+  if (result === undefined) cache.set(symbol, (result = compute()));
+  return result;
+};
+
 /** If `checker` is passed, checks if node (as identifier/expression) is a gql.tada graphql() function */
 export const isTadaGraphQLFunction = (
   node: ts.Node,
   checker: ts.TypeChecker | undefined
 ): node is ts.LeftHandSideExpression => {
-  if (!ts.isLeftHandSideExpression(node)) return false;
-  const type = checker?.getTypeAtLocation(node);
-  // Any function that has both a `scalar` and `persisted` property
-  // is automatically considered a gql.tada graphql() function.
-  return (
-    type != null &&
-    type.getProperty('scalar') != null &&
-    type.getProperty('persisted') != null
-  );
+  if (!ts.isLeftHandSideExpression(node) || !checker) return false;
+  return getCached(tadaFunctionCache, checker, node, () => {
+    const type = checker.getTypeAtLocation(node);
+    // Any function that has both a `scalar` and `persisted` property
+    // is automatically considered a gql.tada graphql() function.
+    return (
+      type != null &&
+      type.getProperty('scalar') != null &&
+      type.getProperty('persisted') != null
+    );
+  });
 };
 
 /** If `checker` is passed, checks if node is a gql.tada graphql() call */
@@ -104,24 +136,27 @@ export const getSchemaName = (
   isTadaPersistedCall = false
 ): string | null => {
   if (!typeChecker) return null;
-  const type = typeChecker.getTypeAtLocation(
-    // When calling `graphql.persisted`, we need to access the `graphql` part of
-    // the expression; `node.expression` is the `.persisted` part
-    isTadaPersistedCall ? node.getChildAt(0).getChildAt(0) : node.expression
-  );
-  if (type) {
-    const brandTypeSymbol = type.getProperty('__name');
-    if (brandTypeSymbol) {
-      const brand = typeChecker.getTypeOfSymbol(brandTypeSymbol);
-      if (brand.isUnionOrIntersection()) {
-        const found = brand.types.find(x => x.isStringLiteral());
-        return found && found.isStringLiteral() ? found.value : null;
-      } else if (brand.isStringLiteral()) {
-        return brand.value;
+  // When calling `graphql.persisted`, we need to access the `graphql` part of
+  // the expression; `node.expression` is the `.persisted` part
+  const expression = isTadaPersistedCall
+    ? node.getChildAt(0).getChildAt(0)
+    : node.expression;
+  return getCached(schemaNameCache, typeChecker, expression, () => {
+    const type = typeChecker.getTypeAtLocation(expression);
+    if (type) {
+      const brandTypeSymbol = type.getProperty('__name');
+      if (brandTypeSymbol) {
+        const brand = typeChecker.getTypeOfSymbol(brandTypeSymbol);
+        if (brand.isUnionOrIntersection()) {
+          const found = brand.types.find(x => x.isStringLiteral());
+          return found && found.isStringLiteral() ? found.value : null;
+        } else if (brand.isStringLiteral()) {
+          return brand.value;
+        }
       }
     }
-  }
-  return null;
+    return null;
+  });
 };
 
 /** Checks if node is a maskFragments() call */

--- a/packages/graphqlsp/src/ast/index.ts
+++ b/packages/graphqlsp/src/ast/index.ts
@@ -127,10 +127,19 @@ export function unrollTadaFragments(
   return wip;
 }
 
+export type FindAllCallExpressionsOptions = {
+  /** Search for externally defined fragment documents.
+   * @defaultValue `true` */
+  searchExternal?: boolean;
+  /** Collect and unroll fragment definitions into the `fragments` result.
+   * @defaultValue `true` */
+  collectFragments?: boolean;
+};
+
 export function findAllCallExpressions(
   sourceFile: ts.SourceFile,
   info: ts.server.PluginCreateInfo,
-  shouldSearchFragments: boolean = true
+  options: boolean | FindAllCallExpressionsOptions = true
 ): {
   nodes: Array<{
     node: ts.StringLiteralLike;
@@ -140,6 +149,8 @@ export function findAllCallExpressions(
   }>;
   fragments: Array<FragmentDefinitionNode>;
 } {
+  const { searchExternal = true, collectFragments = true } =
+    typeof options === 'boolean' ? { searchExternal: options } : options;
   const typeChecker = info.languageService.getProgram()?.getTypeChecker();
   const result: Array<{
     node: ts.StringLiteralLike;
@@ -147,7 +158,25 @@ export function findAllCallExpressions(
     tadaFragmentRefs?: readonly ts.Identifier[];
   }> = [];
   let fragments: Array<FragmentDefinitionNode> = [];
-  let hasTriedToFindFragments = shouldSearchFragments ? false : true;
+  let hasTriedToFindFragments = searchExternal ? false : true;
+
+  // Several references typically resolve to the same fragment definition,
+  // so each identifier's unrolled fragments are shared per resolved symbol
+  const unrolledFragments = new Map<ts.Symbol, FragmentDefinitionNode[]>();
+  const unrollFragmentMemoized = (
+    identifier: ts.Identifier
+  ): FragmentDefinitionNode[] => {
+    const symbol = typeChecker && typeChecker.getSymbolAtLocation(identifier);
+    if (!symbol) return unrollFragment(identifier, info, typeChecker);
+    let unrolled = unrolledFragments.get(symbol);
+    if (!unrolled) {
+      unrolledFragments.set(
+        symbol,
+        (unrolled = unrollFragment(identifier, info, typeChecker))
+      );
+    }
+    return unrolled;
+  };
 
   function find(node: ts.Node): void {
     if (!ts.isCallExpression(node) || checks.isIIFE(node)) {
@@ -165,7 +194,9 @@ export function findAllCallExpressions(
     const fragmentRefs = resolveTadaFragmentArray(node.arguments[1]);
     const isTadaCall = checks.isTadaGraphQLCall(node, typeChecker);
 
-    if (!hasTriedToFindFragments && !fragmentRefs) {
+    if (!collectFragments) {
+      // Skip all fragment collection work when the caller only consumes `nodes`
+    } else if (!hasTriedToFindFragments && !fragmentRefs) {
       // Only collect global fragments if this is NOT a gql.tada call
       if (!isTadaCall) {
         hasTriedToFindFragments = true;
@@ -173,7 +204,7 @@ export function findAllCallExpressions(
       }
     } else if (fragmentRefs) {
       for (const identifier of fragmentRefs) {
-        fragments.push(...unrollFragment(identifier, info, typeChecker));
+        fragments.push(...unrollFragmentMemoized(identifier));
       }
     }
 

--- a/test/unit/findAllCallExpressions.test.ts
+++ b/test/unit/findAllCallExpressions.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+
+import { createTestEnvironment, TADA_GRAPHQL_MODULE } from './language-service';
+import { findAllCallExpressions } from '../../packages/graphqlsp/src/ast';
+
+const FRAGMENT_FIXTURE = `
+  import { graphql } from './graphql';
+  const g = graphql;
+
+  export const PokemonFields = g(\`
+    fragment PokemonFields on Pokemon { id name }
+  \`);
+
+  export const MoreFields = g(\`
+    fragment MoreFields on Pokemon { ...PokemonFields hp }
+  \`, [PokemonFields]);
+
+  const QueryOne = g(\`
+    query One { pokemon { ...MoreFields } }
+  \`, [MoreFields]);
+
+  const QueryTwo = g(\`
+    query Two { pokemon { ...MoreFields } }
+  \`, [MoreFields]);
+`;
+
+const makeEnvironment = () =>
+  createTestEnvironment({
+    '/test-project/graphql.ts': TADA_GRAPHQL_MODULE,
+    '/test-project/index.ts': FRAGMENT_FIXTURE,
+  });
+
+describe('findAllCallExpressions', () => {
+  it('detects tada graphql functions aliased to other names', () => {
+    const { info, getSourceFile } = makeEnvironment();
+    const source = getSourceFile('/test-project/index.ts');
+
+    const { nodes } = findAllCallExpressions(source, info);
+    expect(nodes).toHaveLength(4);
+    expect(nodes.map(x => x.schema)).toEqual([
+      'pokemons',
+      'pokemons',
+      'pokemons',
+      'pokemons',
+    ]);
+    expect(nodes.map(x => x.tadaFragmentRefs?.length)).toEqual([0, 1, 1, 1]);
+  });
+
+  it('collects fragments from fragment arrays, once per reference', () => {
+    const { info, getSourceFile } = makeEnvironment();
+    const source = getSourceFile('/test-project/index.ts');
+
+    const { fragments } = findAllCallExpressions(source, info);
+    expect(fragments.map(fragment => fragment.name.value)).toEqual([
+      // from `MoreFields`' fragment array:
+      'PokemonFields',
+      // from `QueryOne`'s fragment array:
+      'MoreFields',
+      'PokemonFields',
+      // from `QueryTwo`'s fragment array:
+      'MoreFields',
+      'PokemonFields',
+    ]);
+  });
+
+  it('returns identical nodes but no fragments with collectFragments: false', () => {
+    const { info, getSourceFile } = makeEnvironment();
+    const source = getSourceFile('/test-project/index.ts');
+
+    const expected = findAllCallExpressions(source, info);
+    const result = findAllCallExpressions(source, info, {
+      searchExternal: false,
+      collectFragments: false,
+    });
+
+    expect(result.nodes).toEqual(expected.nodes);
+    expect(result.fragments).toEqual([]);
+  });
+
+  it('keeps boolean third argument behavior (searchExternal only)', () => {
+    const { info, getSourceFile } = makeEnvironment();
+    const source = getSourceFile('/test-project/index.ts');
+
+    const expected = findAllCallExpressions(source, info, true);
+    const result = findAllCallExpressions(source, info, false);
+
+    // A boolean only gates the external fragment search; fragment arrays
+    // are still unrolled
+    expect(result.nodes).toEqual(expected.nodes);
+    expect(result.fragments).toEqual(expected.fragments);
+    expect(result.fragments.length).toBeGreaterThan(0);
+  });
+});

--- a/test/unit/language-service.ts
+++ b/test/unit/language-service.ts
@@ -1,0 +1,84 @@
+import ts from 'typescript/lib/tsserverlibrary';
+import { init } from '../../packages/graphqlsp/src/ts';
+
+// The graphqlsp source accesses TypeScript through a live binding that the
+// TSServer normally initializes; for unit tests we initialize it directly.
+init({ typescript: ts });
+
+export { ts };
+
+/** Creates an in-memory language service over the given files, mimicking
+ * the parts of `ts.server.PluginCreateInfo` that the AST utilities use. */
+export function createTestEnvironment(files: Record<string, string>) {
+  const host: ts.LanguageServiceHost = {
+    getScriptFileNames: () => Object.keys(files),
+    getScriptVersion: () => '1',
+    getScriptSnapshot: fileName => {
+      const contents =
+        files[fileName] != null ? files[fileName] : ts.sys.readFile(fileName);
+      return contents != null
+        ? ts.ScriptSnapshot.fromString(contents)
+        : undefined;
+    },
+    getCurrentDirectory: () => process.cwd(),
+    getCompilationSettings: () => ({
+      target: ts.ScriptTarget.ES2020,
+      module: ts.ModuleKind.CommonJS,
+      strict: true,
+    }),
+    getDefaultLibFileName: options => ts.getDefaultLibFilePath(options),
+    fileExists: fileName => fileName in files || ts.sys.fileExists(fileName),
+    readFile: fileName =>
+      files[fileName] != null ? files[fileName] : ts.sys.readFile(fileName),
+  };
+
+  const languageService = ts.createLanguageService(host);
+  const info = {
+    languageService,
+    config: {},
+  } as unknown as ts.server.PluginCreateInfo;
+
+  const getSourceFile = (fileName: string): ts.SourceFile => {
+    const source = languageService.getProgram()!.getSourceFile(fileName);
+    if (!source) throw new Error(`Source file not found: ${fileName}`);
+    return source;
+  };
+
+  return { languageService, info, getSourceFile };
+}
+
+/** A minimal stand-in for a `gql.tada` graphql() function: any function type
+ * with both a `scalar` and a `persisted` property is detected as one. */
+export const TADA_GRAPHQL_MODULE = `
+  export type DocumentNode<Result = unknown, Variables = unknown> = {
+    kind: 'document';
+    __result?: Result;
+    __variables?: Variables;
+  };
+
+  export interface GraphQLTadaLike {
+    (document: string, fragments?: readonly DocumentNode[]): DocumentNode;
+    scalar(name: string, value: unknown): unknown;
+    persisted(id: string): DocumentNode;
+    __name: 'pokemons';
+  }
+
+  export const graphql: GraphQLTadaLike = (() => {
+    throw new Error('unimplemented');
+  }) as unknown as GraphQLTadaLike;
+`;
+
+/** Instruments the program's type checker, counting `getTypeAtLocation`
+ * calls made by code under test. */
+export function countTypeProbes(
+  info: ts.server.PluginCreateInfo
+): () => number {
+  const checker = info.languageService.getProgram()!.getTypeChecker();
+  let count = 0;
+  const original = checker.getTypeAtLocation;
+  checker.getTypeAtLocation = function (node: ts.Node) {
+    count++;
+    return original.call(checker, node);
+  };
+  return () => count;
+}

--- a/test/unit/perf.test.ts
+++ b/test/unit/perf.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  createTestEnvironment,
+  countTypeProbes,
+  TADA_GRAPHQL_MODULE,
+} from './language-service';
+import { findAllCallExpressions } from '../../packages/graphqlsp/src/ast';
+
+const NOISE_CALLS = 2_000;
+const GRAPHQL_CALLS = 50;
+
+/** A file dominated by ordinary, non-GraphQL calls with a string-literal
+ * first argument, as found in real codebases (i18n, tests, validation). */
+const makeNoisyFile = (): string => {
+  const lines = [
+    `import { graphql } from './graphql';`,
+    `const g = graphql;`,
+    `declare const t: (key: string, fallback?: string) => string;`,
+    `declare function describeCase(name: string, fn: () => void): void;`,
+    `declare function itCase(name: string, fn: () => void): void;`,
+    `declare const logger: {`,
+    `  info(message: string): void;`,
+    `  warn(message: string): void;`,
+    `};`,
+  ];
+  const callees = ['t', 'describeCase', 'itCase', 'logger.info', 'logger.warn'];
+  for (let i = 0; i < NOISE_CALLS; i++) {
+    const callee = callees[i % callees.length];
+    lines.push(
+      callee === 'describeCase' || callee === 'itCase'
+        ? `${callee}('case ${i}', () => {});`
+        : `${callee}('some.key.${i}');`
+    );
+  }
+  for (let i = 0; i < GRAPHQL_CALLS; i++) {
+    const callee = i % 2 ? 'graphql' : 'g';
+    lines.push(`const Query${i} = ${callee}(\`query Q${i} { field }\`);`);
+  }
+  return lines.join('\n');
+};
+
+/** A file with many queries sharing the same fragment dependencies. */
+const makeSharedFragmentsFile = (queries: number): string => {
+  const lines = [
+    `import { graphql } from './graphql';`,
+    `const g = graphql;`,
+    `export const FieldsA = g(\`fragment FieldsA on Pokemon { id }\`);`,
+    `export const FieldsB = g(\`fragment FieldsB on Pokemon { ...FieldsA name }\`, [FieldsA]);`,
+  ];
+  for (let i = 0; i < queries; i++) {
+    lines.push(
+      `const Query${i} = g(\`query Q${i} { pokemon { ...FieldsB } } \`, [FieldsB]);`
+    );
+  }
+  return lines.join('\n');
+};
+
+describe('findAllCallExpressions perf', () => {
+  it('probes the type checker per distinct callee, not per call site', () => {
+    const { info, getSourceFile } = createTestEnvironment({
+      '/test-project/graphql.ts': TADA_GRAPHQL_MODULE,
+      '/test-project/index.ts': makeNoisyFile(),
+    });
+    const source = getSourceFile('/test-project/index.ts');
+    const getProbeCount = countTypeProbes(info);
+
+    const start = performance.now();
+    const { nodes } = findAllCallExpressions(source, info);
+    const duration = performance.now() - start;
+
+    expect(nodes).toHaveLength(GRAPHQL_CALLS);
+    const probes = getProbeCount();
+    // eslint-disable-next-line no-console
+    console.log(
+      `[perf] noisy file (${NOISE_CALLS} noise + ${GRAPHQL_CALLS} graphql calls): ` +
+        `${probes} type probes, ${duration.toFixed(1)}ms`
+    );
+
+    // 7 distinct callees (t, describeCase, itCase, logger.info, logger.warn,
+    // graphql, g); a generous bound that is far below one probe per call site
+    expect(probes).toBeLessThan(NOISE_CALLS / 10);
+  });
+
+  it('skips fragment unrolling entirely with collectFragments: false', () => {
+    const queries = 200;
+    const { info, getSourceFile } = createTestEnvironment({
+      '/test-project/graphql.ts': TADA_GRAPHQL_MODULE,
+      '/test-project/index.ts': makeSharedFragmentsFile(queries),
+    });
+    const source = getSourceFile('/test-project/index.ts');
+
+    const start = performance.now();
+    const result = findAllCallExpressions(source, info, {
+      searchExternal: false,
+      collectFragments: false,
+    });
+    const duration = performance.now() - start;
+
+    expect(result.nodes).toHaveLength(queries + 2);
+    expect(result.fragments).toEqual([]);
+    // eslint-disable-next-line no-console
+    console.log(
+      `[perf] shared fragments (${queries} queries, collectFragments: false): ` +
+        `${duration.toFixed(1)}ms`
+    );
+  });
+
+  it('deduplicates fragment unrolling for repeated references', () => {
+    const queries = 200;
+    const { info, getSourceFile } = createTestEnvironment({
+      '/test-project/graphql.ts': TADA_GRAPHQL_MODULE,
+      '/test-project/index.ts': makeSharedFragmentsFile(queries),
+    });
+    const source = getSourceFile('/test-project/index.ts');
+
+    const start = performance.now();
+    const { nodes, fragments } = findAllCallExpressions(source, info);
+    const duration = performance.now() - start;
+
+    expect(nodes).toHaveLength(queries + 2);
+    // each query reference contributes FieldsB + FieldsA, and the FieldsB
+    // definition's own fragment array contributes FieldsA
+    expect(fragments).toHaveLength(queries * 2 + 1);
+    // eslint-disable-next-line no-console
+    console.log(
+      `[perf] shared fragments (${queries} queries, default): ` +
+        `${duration.toFixed(1)}ms`
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Two independent fixes to the cost of `findAllCallExpressions`, found while profiling the `turbo` command of gql.tada:

1. **Memoize the gql.tada type probe per callee.** `isTadaGraphQLFunction` (and `getSchemaName`) called `checker.getTypeAtLocation` for *every* call expression with a string-literal first argument — every `t('key')`, `it('name', fn)`, logger call, etc. in a file. The verdict never changes for a given callee within one program, so it is now cached per callee symbol in a `WeakMap` keyed by the checker instance (a new program comes with a new checker, so invalidation is automatic). Callees without a resolvable symbol fall through to the uncached path.

2. **Make fragment collection optional and deduplicated.** The third parameter of `findAllCallExpressions` now also accepts an options object (`{ searchExternal?: boolean; collectFragments?: boolean }`); a boolean keeps its old meaning (`searchExternal`). With `collectFragments: false`, fragment unrolling and the external fragment search are skipped entirely and `fragments` is `[]` — for callers like the gql.tada `turbo` command that only consume `nodes`. On the default path, `unrollFragment` results are now shared per resolved fragment symbol within an invocation, so a fragment referenced by many queries in one file is resolved once (output is unchanged, including per-reference duplicates).

Default behavior is unchanged; this is an API addition shipped as a minor.

## Measurements

From the new perf tests (`test/unit/perf.test.ts`, in-memory language service, Windows):

| Scenario | Before | After |
| --- | --- | --- |
| 2,000 non-GraphQL string-arg calls + 50 `graphql()` calls: type probes | 2,125 | 9 (7 distinct callees + 2 schema-name probes) |
| same, wall time | ~93ms | ~55ms |
| 200 queries sharing 2 fragments, default | ~19ms | ~8ms |
| same, `collectFragments: false` | — | ~4ms |

On the gql.tada side, disabling fragment unrolling via a `getDefinitionAtPosition` proxy (what `collectFragments: false` replaces) cut `findAllCallExpressions` from 129–176ms to 36–59ms on a 300-file/902-document synthetic project, with byte-identical turbo output.

## Tests

- New unit-test harness (`test/unit/`) running `findAllCallExpressions` against an in-memory language service; picked up by the existing `vitest run` in CI.
- Regression test that a tada-style `graphql` function aliased to another name (`const g = graphql`) is still detected — the case the type probe exists for.
- `collectFragments: false` returns identical `nodes`; boolean third argument behaves exactly as before; fragment output on the default path is unchanged (including duplicates per reference).
- Perf test asserts the probe count is O(distinct callees), not O(call sites).
- e2e suite: the 15 failures on my machine are identical with and without this change (verified by stashing and re-running) — pre-existing local environment failures, not regressions.

Follow-up (gql.tada repo): bump the dependency, pass `{ searchExternal: false, collectFragments: false }` in the turbo thread, and delete the `wrapPluginInfoForTurbo` workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
