### PR TITLE
Rewrite unused field detection as a single-pass symbol-driven analysis

### DIFF
--- a/.changeset/spotty-candles-shake.md
+++ b/.changeset/spotty-candles-shake.md
@@ -1,0 +1,7 @@
+---
+'@0no-co/graphqlsp': minor
+---
+
+Rewrite unused field detection as a single-pass, symbol-driven analysis. Instead of issuing a find-all-references request per binding and enumerating the lexical scope per reference, the file's AST is walked once to index identifier occurrences, and query-result bindings are resolved through `getSymbolAtLocation` against a selection-set trie. This removes the quadratic language-service calls from `getSemanticDiagnostics`, scales to files with many documents and consumers, and makes the analysis work without resolved document types.
+
+The analysis also tracks more usage patterns, reducing false positives: values passed as function arguments (including property chains like `format(data.pokemon.weight)`), spreads and object-literal assignments now mark the affected sub-selections as used, `for...of` loop bindings are followed like array-method callbacks, and assignments (`existing = result.data.pokemon`) and conditional expressions now alias like variable declarations.

--- a/packages/graphqlsp/src/fieldUsage.ts
+++ b/packages/graphqlsp/src/fieldUsage.ts
@@ -1,7 +1,6 @@
 import { ts } from './ts';
 import { parse, visit } from 'graphql';
 
-import { findNode } from './ast';
 import { getValueOfIdentifier } from './ast/declaration';
 
 export const UNUSED_FIELD_CODE = 52005;
@@ -27,87 +26,6 @@ const getVariableDeclaration = (
   }
 };
 
-const traverseArrayDestructuring = (
-  node: ts.ArrayBindingPattern,
-  originalWip: Array<string>,
-  allFields: Array<string>,
-  source: ts.SourceFile,
-  info: ts.server.PluginCreateInfo
-): Array<string> => {
-  return node.elements.flatMap(element => {
-    if (ts.isOmittedExpression(element)) return [];
-
-    const wip = [...originalWip];
-    return ts.isIdentifier(element.name)
-      ? crawlScope(element.name, wip, allFields, source, info, false)
-      : ts.isObjectBindingPattern(element.name)
-      ? traverseDestructuring(element.name, wip, allFields, source, info)
-      : traverseArrayDestructuring(element.name, wip, allFields, source, info);
-  });
-};
-
-const traverseDestructuring = (
-  node: ts.ObjectBindingPattern,
-  originalWip: Array<string>,
-  allFields: Array<string>,
-  source: ts.SourceFile,
-  info: ts.server.PluginCreateInfo
-): Array<string> => {
-  const results = [];
-  for (const binding of node.elements) {
-    if (ts.isObjectBindingPattern(binding.name)) {
-      const wip = [...originalWip];
-      if (
-        binding.propertyName &&
-        !originalWip.includes(binding.propertyName.getText())
-      ) {
-        const joined = [...wip, binding.propertyName.getText()].join('.');
-        if (allFields.find(x => x.startsWith(joined))) {
-          wip.push(binding.propertyName.getText());
-        }
-      }
-      const traverseResult = traverseDestructuring(
-        binding.name,
-        wip,
-        allFields,
-        source,
-        info
-      );
-
-      results.push(...traverseResult);
-    } else if (ts.isIdentifier(binding.name)) {
-      const wip = [...originalWip];
-      if (
-        binding.propertyName &&
-        !originalWip.includes(binding.propertyName.getText())
-      ) {
-        const joined = [...wip, binding.propertyName.getText()].join('.');
-        if (allFields.find(x => x.startsWith(joined))) {
-          wip.push(binding.propertyName.getText());
-        }
-      } else {
-        const joined = [...wip, binding.name.getText()].join('.');
-        if (allFields.find(x => x.startsWith(joined))) {
-          wip.push(binding.name.getText());
-        }
-      }
-
-      const crawlResult = crawlScope(
-        binding.name,
-        wip,
-        allFields,
-        source,
-        info,
-        false
-      );
-
-      results.push(...crawlResult);
-    }
-  }
-
-  return results;
-};
-
 const arrayMethods = new Set([
   'map',
   'filter',
@@ -120,269 +38,76 @@ const arrayMethods = new Set([
   'sort',
 ]);
 
-const crawlChainedExpressions = (
-  ref: ts.CallExpression,
-  pathParts: string[],
-  allFields: string[],
-  source: ts.SourceFile,
-  info: ts.server.PluginCreateInfo
-): string[] => {
-  const isChained =
-    ts.isPropertyAccessExpression(ref.expression) &&
-    arrayMethods.has(ref.expression.name.text);
-  if (isChained) {
-    const foundRef = ref.expression;
-    const isReduce = foundRef.name.text === 'reduce';
-    let func: ts.Expression | ts.FunctionDeclaration | undefined =
-      ref.arguments[0];
+/** A node in the selection-set trie of a single GraphQL document.
+ * Keys are the response-shape keys, i.e. the alias when one is present. */
+interface TrieNode {
+  id: number;
+  children: Map<string, TrieNode>;
+  isLeaf: boolean;
+  used: boolean;
+}
 
-    const res = [];
-    if (ts.isCallExpression(ref.parent.parent)) {
-      const nestedResult = crawlChainedExpressions(
-        ref.parent.parent,
-        pathParts,
-        allFields,
-        source,
-        info
-      );
-      if (nestedResult.length) {
-        res.push(...nestedResult);
-      }
-    }
+interface DocumentState {
+  root: TrieNode;
+  /** Leaf-paths in document order, used to keep diagnostic ordering stable. */
+  allPaths: string[];
+  leafByPath: Map<string, TrieNode>;
+  fieldToLoc: Map<string, { start: number; length: number }>;
+  templateNode: ts.NoSubstitutionTemplateLiteral;
+  /** Number of terminal accesses we saw; no access means the result is
+   * consumed elsewhere (other files) and we stay silent. */
+  accessCount: number;
+}
 
-    if (func && ts.isIdentifier(func)) {
-      // TODO: Scope utilities in checkFieldUsageInFile to deduplicate
-      const checker = info.languageService.getProgram()!.getTypeChecker();
+/** A tracked binding: occurrences of `symbol` represent the data at trie
+ * position `node` of document `doc`. */
+interface Entry {
+  symbol: ts.Symbol;
+  node: TrieNode;
+  doc: DocumentState;
+  /** Set for array-method callback params; returning from those callbacks
+   * is not an escape of the data (`list.map(x => x.field)`). */
+  suppressReturnBail: boolean;
+}
 
-      const value = getValueOfIdentifier(func, checker);
-      if (
-        value &&
-        (ts.isFunctionDeclaration(value) ||
-          ts.isFunctionExpression(value) ||
-          ts.isArrowFunction(value))
-      ) {
-        func = value;
-      }
-    }
+/** Resolves the data-type of a document, either from internally resolved
+ * type-arguments or through the `__apiType` call-signature. */
+const resolveDataType = (
+  node: ts.Node,
+  checker: ts.TypeChecker
+): ts.Type | undefined => {
+  let dataType: ts.Type | undefined;
 
-    if (
-      func &&
-      (ts.isFunctionDeclaration(func) ||
-        ts.isFunctionExpression(func) ||
-        ts.isArrowFunction(func))
-    ) {
-      const param = func.parameters[isReduce ? 1 : 0];
-      if (param) {
-        const scopedResult = crawlScope(
-          param.name,
-          pathParts,
-          allFields,
-          source,
-          info,
-          true
-        );
-
-        if (scopedResult.length) {
-          res.push(...scopedResult);
+  const type = checker.getTypeAtLocation(node.parent) as
+    | ts.TypeReference
+    | ts.Type;
+  // Attempt to retrieve type from internally resolve type arguments
+  if ('target' in type) {
+    const typeArguments = (type as any)
+      .resolvedTypeArguments as readonly ts.Type[];
+    dataType =
+      typeArguments && typeArguments.length > 1 ? typeArguments[0] : undefined;
+  }
+  // Fallback to resolving the type from scratch
+  if (!dataType) {
+    const apiTypeSymbol = type.getProperty('__apiType');
+    if (apiTypeSymbol) {
+      let apiType = checker.getTypeOfSymbol(apiTypeSymbol);
+      let callSignature: ts.Signature | undefined = type.getCallSignatures()[0];
+      if (apiType.isUnionOrIntersection()) {
+        for (const type of apiType.types) {
+          callSignature = type.getCallSignatures()[0];
+          if (callSignature) {
+            dataType = callSignature.getReturnType();
+            break;
+          }
         }
       }
+      dataType = callSignature && callSignature.getReturnType();
     }
-
-    return res;
   }
 
-  return [];
-};
-
-const crawlScope = (
-  node: ts.BindingName,
-  originalWip: Array<string>,
-  allFields: Array<string>,
-  source: ts.SourceFile,
-  info: ts.server.PluginCreateInfo,
-  inArrayMethod: boolean
-): Array<string> => {
-  if (ts.isObjectBindingPattern(node)) {
-    return traverseDestructuring(node, originalWip, allFields, source, info);
-  } else if (ts.isArrayBindingPattern(node)) {
-    return traverseArrayDestructuring(
-      node,
-      originalWip,
-      allFields,
-      source,
-      info
-    );
-  }
-
-  let results: string[] = [];
-
-  const references = info.languageService.getReferencesAtPosition(
-    source.fileName,
-    node.getStart()
-  );
-
-  if (!references) return results;
-
-  // Go over all the references tied to the result of
-  // accessing our equery and collect them as fully
-  // qualified paths (ideally ending in a leaf-node)
-  results = references.flatMap(ref => {
-    // If we get a reference to a different file we can bail
-    if (ref.fileName !== source.fileName) return [];
-    // We don't want to end back at our document so we narrow
-    // the scope.
-    if (
-      node.getStart() <= ref.textSpan.start &&
-      node.getEnd() >= ref.textSpan.start + ref.textSpan.length
-    )
-      return [];
-
-    let foundRef = findNode(source, ref.textSpan.start);
-    if (!foundRef) return [];
-
-    const pathParts = [...originalWip];
-    // In here we'll start crawling all the accessors of result
-    // and try to determine the total path
-    // - result.data.pokemon.name --> pokemon.name this is the easy route and never accesses
-    //   any of the recursive functions
-    // - const pokemon = result.data.pokemon --> this initiates a new crawl with a renewed scope
-    // - const { pokemon } = result.data --> this initiates a destructuring traversal which will
-    //   either end up in more destructuring traversals or a scope crawl
-    while (
-      ts.isIdentifier(foundRef) ||
-      ts.isPropertyAccessExpression(foundRef) ||
-      ts.isElementAccessExpression(foundRef) ||
-      ts.isVariableDeclaration(foundRef) ||
-      ts.isBinaryExpression(foundRef) ||
-      ts.isReturnStatement(foundRef) ||
-      ts.isArrowFunction(foundRef)
-    ) {
-      if (
-        !inArrayMethod &&
-        (ts.isReturnStatement(foundRef) || ts.isArrowFunction(foundRef))
-      ) {
-        // When we are returning the ref or we are dealing with an implicit return
-        // we mark all its children as used (bail scenario)
-        const joined = pathParts.join('.');
-        const bailedFields = allFields.filter(x => x.startsWith(joined + '.'));
-        return bailedFields;
-      } else if (ts.isVariableDeclaration(foundRef)) {
-        return crawlScope(
-          foundRef.name,
-          pathParts,
-          allFields,
-          source,
-          info,
-          false
-        );
-      } else if (
-        ts.isIdentifier(foundRef) &&
-        !pathParts.includes(foundRef.text)
-      ) {
-        const joined = [...pathParts, foundRef.text].join('.');
-        if (allFields.find(x => x.startsWith(joined + '.'))) {
-          pathParts.push(foundRef.text);
-        }
-
-        // When we encounter an external function where we use this identifier
-        // we'll mark all of the sub-fields as used as we consider this a bail
-        // scenario.
-        if (ts.isCallExpression(foundRef.parent)) {
-          const callExpression = foundRef.parent;
-          return callExpression.arguments.flatMap(arg => {
-            let parts = [...pathParts];
-            let reference = arg;
-
-            while (ts.isPropertyAccessExpression(reference)) {
-              const joined = [...parts, reference.name.text].join('.');
-              if (allFields.find(x => x.startsWith(joined + '.'))) {
-                parts.push(reference.name.text);
-              }
-              reference = reference.expression;
-            }
-
-            if (ts.isIdentifier(reference)) {
-              const joined = [...parts, reference.getText()].join('.');
-              if (allFields.find(x => x.startsWith(joined + '.'))) {
-                parts.push(reference.getText());
-              }
-            }
-
-            const joined = parts.join('.');
-            return allFields.filter(x => x.startsWith(joined + '.'));
-          });
-        }
-      } else if (
-        ts.isPropertyAccessExpression(foundRef) &&
-        foundRef.name.text === 'at' &&
-        ts.isCallExpression(foundRef.parent)
-      ) {
-        foundRef = foundRef.parent;
-      } else if (
-        ts.isPropertyAccessExpression(foundRef) &&
-        arrayMethods.has(foundRef.name.text) &&
-        ts.isCallExpression(foundRef.parent)
-      ) {
-        const callExpression = foundRef.parent;
-        const res = [];
-        const isSomeOrEvery =
-          foundRef.name.text === 'some' || foundRef.name.text === 'every';
-        const chainedResults = crawlChainedExpressions(
-          callExpression,
-          pathParts,
-          allFields,
-          source,
-          info
-        );
-        if (chainedResults.length) {
-          res.push(...chainedResults);
-        }
-
-        if (ts.isVariableDeclaration(callExpression.parent) && !isSomeOrEvery) {
-          const varRes = crawlScope(
-            callExpression.parent.name,
-            pathParts,
-            allFields,
-            source,
-            info,
-            true
-          );
-          res.push(...varRes);
-        }
-
-        return res;
-      } else if (
-        ts.isPropertyAccessExpression(foundRef) &&
-        !pathParts.includes(foundRef.name.text)
-      ) {
-        const joined = [...pathParts, foundRef.name.text].join('.');
-        if (allFields.find(x => x.startsWith(joined))) {
-          pathParts.push(foundRef.name.text);
-        }
-      } else if (
-        ts.isElementAccessExpression(foundRef) &&
-        ts.isStringLiteral(foundRef.argumentExpression) &&
-        !pathParts.includes(foundRef.argumentExpression.text)
-      ) {
-        const joined = [...pathParts, foundRef.argumentExpression.text].join(
-          '.'
-        );
-        if (allFields.find(x => x.startsWith(joined))) {
-          pathParts.push(foundRef.argumentExpression.text);
-        }
-      }
-
-      if (ts.isNonNullExpression(foundRef.parent)) {
-        foundRef = foundRef.parent.parent;
-      } else {
-        foundRef = foundRef.parent;
-      }
-    }
-
-    return pathParts.join('.');
-  });
-
-  return results;
+  return dataType;
 };
 
 export const checkFieldUsageInFile = (
@@ -401,174 +126,584 @@ export const checkFieldUsageInFile = (
   if (!checker) return;
 
   try {
-    nodes.forEach(node => {
+    let trieId = 0;
+    const makeTrieNode = (isLeaf: boolean): TrieNode => ({
+      id: trieId++,
+      children: new Map(),
+      isLeaf,
+      used: false,
+    });
+
+    // Phase A: collect the selection-set trie for every document in the file
+    const docStates: DocumentState[] = [];
+    for (const node of nodes) {
       const nodeText = node.getText();
       // Bailing for mutations/subscriptions as these could have small details
       // for normalised cache interactions
       if (nodeText.includes('mutation') || nodeText.includes('subscription'))
-        return;
+        continue;
 
-      const variableDeclaration = getVariableDeclaration(node);
-      if (!variableDeclaration) return;
-
-      let dataType: ts.Type | undefined;
-
-      const type = checker.getTypeAtLocation(node.parent) as
-        | ts.TypeReference
-        | ts.Type;
-      // Attempt to retrieve type from internally resolve type arguments
-      if ('target' in type) {
-        const typeArguments = (type as any)
-          .resolvedTypeArguments as readonly ts.Type[];
-        dataType =
-          typeArguments && typeArguments.length > 1
-            ? typeArguments[0]
-            : undefined;
-      }
-      // Fallback to resolving the type from scratch
-      if (!dataType) {
-        const apiTypeSymbol = type.getProperty('__apiType');
-        if (apiTypeSymbol) {
-          let apiType = checker.getTypeOfSymbol(apiTypeSymbol);
-          let callSignature: ts.Signature | undefined =
-            type.getCallSignatures()[0];
-          if (apiType.isUnionOrIntersection()) {
-            for (const type of apiType.types) {
-              callSignature = type.getCallSignatures()[0];
-              if (callSignature) {
-                dataType = callSignature.getReturnType();
-                break;
-              }
-            }
-          }
-          dataType = callSignature && callSignature.getReturnType();
-        }
+      let document;
+      try {
+        document = parse(nodeText.slice(1, -1));
+      } catch (_e) {
+        continue;
       }
 
-      const references = info.languageService.getReferencesAtPosition(
-        source.fileName,
-        variableDeclaration.name.getStart()
-      );
-
-      if (!references) return;
-
-      const allAccess: string[] = [];
-      const inProgress: string[] = [];
+      const root = makeTrieNode(false);
       const allPaths: string[] = [];
+      const leafByPath = new Map<string, TrieNode>();
       const fieldToLoc = new Map<string, { start: number; length: number }>();
+      const inProgress: string[] = [];
+      const trieStack: TrieNode[] = [root];
       // This visitor gets all the leaf-paths in the document
-      // as well as all fields that are part of the document
-      // We need the leaf-paths to check usage and we need the
-      // fields to validate whether an access on a given reference
-      // is valid given the current document...
-      visit(parse(node.getText().slice(1, -1)), {
+      // as well as all fields that are part of the document.
+      // We need the leaf-paths to check usage and the trie to
+      // resolve whether an access on a given reference is valid
+      // for the current document...
+      visit(document, {
         Field: {
-          enter(node) {
-            const alias = node.alias ? node.alias.value : node.name.value;
+          enter(fieldNode) {
+            const alias = fieldNode.alias
+              ? fieldNode.alias.value
+              : fieldNode.name.value;
             const path = inProgress.length
               ? `${inProgress.join('.')}.${alias}`
               : alias;
+            const parent = trieStack[trieStack.length - 1];
 
-            if (!node.selectionSet && !reservedKeys.has(node.name.value)) {
+            if (
+              !fieldNode.selectionSet &&
+              !reservedKeys.has(fieldNode.name.value)
+            ) {
               allPaths.push(path);
               fieldToLoc.set(path, {
-                start: node.name.loc!.start,
-                length: node.name.loc!.end - node.name.loc!.start,
+                start: fieldNode.name.loc!.start,
+                length: fieldNode.name.loc!.end - fieldNode.name.loc!.start,
               });
-            } else if (node.selectionSet) {
+              let trieNode = parent.children.get(alias);
+              if (!trieNode) {
+                parent.children.set(alias, (trieNode = makeTrieNode(true)));
+              } else {
+                trieNode.isLeaf = true;
+              }
+              leafByPath.set(path, trieNode);
+            } else if (fieldNode.selectionSet) {
               inProgress.push(alias);
               fieldToLoc.set(path, {
-                start: node.name.loc!.start,
-                length: node.name.loc!.end - node.name.loc!.start,
+                start: fieldNode.name.loc!.start,
+                length: fieldNode.name.loc!.end - fieldNode.name.loc!.start,
               });
+              let trieNode = parent.children.get(alias);
+              if (!trieNode) {
+                parent.children.set(alias, (trieNode = makeTrieNode(false)));
+              }
+              trieStack.push(trieNode);
             }
           },
-          leave(node) {
-            if (node.selectionSet) {
+          leave(fieldNode) {
+            if (fieldNode.selectionSet) {
               inProgress.pop();
+              trieStack.pop();
             }
           },
         },
       });
 
-      references.forEach(ref => {
-        if (ref.fileName !== source.fileName) return;
-
-        const targetNode = findNode(source, ref.textSpan.start);
-        if (!targetNode) return;
-        // Skip declaration as reference of itself
-        if (targetNode.parent === variableDeclaration) return;
-
-        const scopeSymbols = checker.getSymbolsInScope(
-          targetNode,
-          ts.SymbolFlags.BlockScopedVariable
-        );
-
-        let scopeDataSymbol: ts.Symbol | undefined;
-        for (let scopeSymbol of scopeSymbols) {
-          if (!scopeSymbol.valueDeclaration) continue;
-          let typeOfScopeSymbol = unwrapAbstractType(
-            checker.getTypeOfSymbol(scopeSymbol)
-          );
-          if (dataType === typeOfScopeSymbol) {
-            scopeDataSymbol = scopeSymbol;
-            break;
-          }
-
-          // NOTE: This is an aggressive fallback for hooks where the return value isn't destructured
-          // This is a last resort solution for patterns like react-query, where the fallback that
-          // would otherwise happen below isn't sufficient
-          if (typeOfScopeSymbol.flags & ts.TypeFlags.Object) {
-            const tuplePropertySymbol = typeOfScopeSymbol.getProperty('0');
-            if (tuplePropertySymbol) {
-              typeOfScopeSymbol = checker.getTypeOfSymbol(tuplePropertySymbol);
-              if (dataType === typeOfScopeSymbol) {
-                scopeDataSymbol = scopeSymbol;
-                break;
-              }
-            }
-
-            const dataPropertySymbol = typeOfScopeSymbol.getProperty('data');
-            if (dataPropertySymbol) {
-              typeOfScopeSymbol = unwrapAbstractType(
-                checker.getTypeOfSymbol(dataPropertySymbol)
-              );
-              if (dataType === typeOfScopeSymbol) {
-                scopeDataSymbol = scopeSymbol;
-                break;
-              }
-            }
-          }
-        }
-
-        const valueDeclaration = scopeDataSymbol?.valueDeclaration;
-        let name: ts.BindingName | undefined;
-        if (
-          valueDeclaration &&
-          'name' in valueDeclaration &&
-          !!valueDeclaration.name &&
-          (ts.isIdentifier(valueDeclaration.name as any) ||
-            ts.isBindingName(valueDeclaration.name as any))
-        ) {
-          name = valueDeclaration.name as ts.BindingName;
-        } else {
-          // Fall back to looking at the variable declaration directly,
-          // if we are on one.
-          const variableDeclaration = getVariableDeclaration(targetNode);
-          if (variableDeclaration) name = variableDeclaration.name;
-        }
-
-        if (name) {
-          const result = crawlScope(name, [], allPaths, source, info, false);
-          allAccess.push(...result);
-        }
+      docStates.push({
+        root,
+        allPaths,
+        leafByPath,
+        fieldToLoc,
+        templateNode: node,
+        accessCount: 0,
       });
+    }
 
-      if (!allAccess.length) {
+    if (!docStates.length) return diagnostics;
+
+    // Phase B1: one pass over the file collecting identifier occurrences by
+    // name (value positions only) and call-initialized declarations. This
+    // replaces per-binding find-all-references searches.
+    const identifiersByName = new Map<string, ts.Identifier[]>();
+    const callInitializedDecls: ts.VariableDeclaration[] = [];
+    const indexWalk = (node: ts.Node) => {
+      if (ts.isTypeNode(node)) return;
+
+      if (ts.isIdentifier(node)) {
+        const parent = node.parent;
+        // Skip declaration names (a declaration is not a use of itself)
+        // and property-name positions (they resolve to unrelated symbols).
+        const isDeclarationName =
+          parent &&
+          (ts.isVariableDeclaration(parent) ||
+            ts.isBindingElement(parent) ||
+            ts.isParameter(parent) ||
+            ts.isFunctionDeclaration(parent) ||
+            ts.isFunctionExpression(parent) ||
+            ts.isClassDeclaration(parent) ||
+            ts.isImportSpecifier(parent) ||
+            ts.isImportClause(parent) ||
+            ts.isNamespaceImport(parent) ||
+            ts.isExportSpecifier(parent)) &&
+          parent.name === node;
+        const isPropertyName =
+          parent &&
+          ((ts.isPropertyAccessExpression(parent) && parent.name === node) ||
+            (ts.isQualifiedName(parent) && parent.right === node) ||
+            (ts.isPropertyAssignment(parent) && parent.name === node) ||
+            (ts.isBindingElement(parent) && parent.propertyName === node) ||
+            (ts.isJsxAttribute(parent) && parent.name === node) ||
+            (ts.isPropertyDeclaration(parent) && parent.name === node) ||
+            (ts.isMethodDeclaration(parent) && parent.name === node) ||
+            (ts.isPropertySignature(parent) && parent.name === node) ||
+            (ts.isMethodSignature(parent) && parent.name === node) ||
+            (ts.isEnumMember(parent) && parent.name === node));
+        if (!isDeclarationName && !isPropertyName) {
+          let list = identifiersByName.get(node.text);
+          if (!list) identifiersByName.set(node.text, (list = []));
+          list.push(node);
+        }
         return;
       }
 
-      const unused = allPaths.filter(x => !allAccess.includes(x));
+      if (ts.isVariableDeclaration(node) && node.initializer) {
+        let init: ts.Expression = node.initializer;
+        while (
+          ts.isParenthesizedExpression(init) ||
+          ts.isAwaitExpression(init) ||
+          ts.isNonNullExpression(init) ||
+          ts.isAsExpression(init)
+        ) {
+          init = init.expression;
+        }
+        if (ts.isCallExpression(init)) callInitializedDecls.push(node);
+      }
+
+      ts.forEachChild(node, indexWalk);
+    };
+    indexWalk(source);
+
+    const symbolCache = new Map<ts.Identifier, ts.Symbol | undefined>();
+    const getRefSymbol = (id: ts.Identifier): ts.Symbol | undefined => {
+      if (symbolCache.has(id)) return symbolCache.get(id);
+      const sym =
+        ts.isShorthandPropertyAssignment(id.parent) && id.parent.name === id
+          ? checker.getShorthandAssignmentValueSymbol(id.parent)
+          : checker.getSymbolAtLocation(id);
+      symbolCache.set(id, sym);
+      return sym;
+    };
+
+    // Phase B2: the tracker holds bindings whose occurrences we still have to
+    // visit. The seen-set makes the worklist converge on alias cycles.
+    const queue: Entry[] = [];
+    const seenEntries = new Map<ts.Symbol, Set<string>>();
+    const addEntry = (
+      symbol: ts.Symbol | undefined,
+      node: TrieNode,
+      doc: DocumentState,
+      suppressReturnBail: boolean
+    ) => {
+      if (!symbol) return;
+      let keys = seenEntries.get(symbol);
+      if (!keys) seenEntries.set(symbol, (keys = new Set()));
+      const key = `${node.id}${suppressReturnBail ? 's' : ''}`;
+      if (keys.has(key)) return;
+      keys.add(key);
+      queue.push({ symbol, node, doc, suppressReturnBail });
+    };
+
+    /** Registers a binding-name at a trie position: identifiers become
+     * tracked entries, destructuring patterns descend through the trie.
+     * Keys that aren't part of the document (`data`, tuple wrappers) are
+     * passed through without descending. */
+    const trackBinding = (
+      name: ts.BindingName,
+      trieNode: TrieNode,
+      doc: DocumentState,
+      suppressReturnBail: boolean
+    ) => {
+      if (ts.isIdentifier(name)) {
+        addEntry(
+          checker.getSymbolAtLocation(name),
+          trieNode,
+          doc,
+          suppressReturnBail
+        );
+      } else if (ts.isObjectBindingPattern(name)) {
+        for (const element of name.elements) {
+          let key: string | undefined;
+          if (element.propertyName) {
+            if (
+              ts.isIdentifier(element.propertyName) ||
+              ts.isStringLiteral(element.propertyName)
+            ) {
+              key = element.propertyName.text;
+            }
+          } else if (ts.isIdentifier(element.name)) {
+            key = element.name.text;
+          }
+          const next = (key && trieNode.children.get(key)) || trieNode;
+          trackBinding(element.name, next, doc, suppressReturnBail);
+        }
+      } else {
+        for (const element of name.elements) {
+          if (ts.isOmittedExpression(element)) continue;
+          // Array/tuple wrappers don't influence the field path
+          trackBinding(element.name, trieNode, doc, suppressReturnBail);
+        }
+      }
+    };
+
+    const markSubtreeUsed = (trieNode: TrieNode) => {
+      for (const child of trieNode.children.values()) {
+        child.used = true;
+        markSubtreeUsed(child);
+      }
+    };
+
+    /** Seeds the callbacks of an array-method chain
+     * (`x.filter(a => ...).map(b => ...)`) and, when the chain result is
+     * assigned, tracks that binding at the same trie position. */
+    const handleArrayChain = (
+      firstCall: ts.CallExpression,
+      firstMethod: string,
+      trieNode: TrieNode,
+      doc: DocumentState
+    ) => {
+      let call = firstCall;
+      while (true) {
+        const method = (call.expression as ts.PropertyAccessExpression).name
+          .text;
+        let func: ts.Node | undefined = call.arguments[0];
+        if (func && ts.isIdentifier(func)) {
+          const value = getValueOfIdentifier(func, checker);
+          if (
+            value &&
+            (ts.isFunctionDeclaration(value) ||
+              ts.isFunctionExpression(value) ||
+              ts.isArrowFunction(value))
+          ) {
+            func = value;
+          }
+        }
+        if (
+          func &&
+          (ts.isFunctionDeclaration(func) ||
+            ts.isFunctionExpression(func) ||
+            ts.isArrowFunction(func))
+        ) {
+          const param = func.parameters[method === 'reduce' ? 1 : 0];
+          if (param) trackBinding(param.name, trieNode, doc, true);
+        }
+
+        const access = call.parent;
+        if (
+          ts.isPropertyAccessExpression(access) &&
+          access.expression === call &&
+          arrayMethods.has(access.name.text) &&
+          ts.isCallExpression(access.parent) &&
+          access.parent.expression === access
+        ) {
+          call = access.parent;
+          continue;
+        }
+        break;
+      }
+
+      if (
+        ts.isVariableDeclaration(firstCall.parent) &&
+        firstMethod !== 'some' &&
+        firstMethod !== 'every'
+      ) {
+        trackBinding(firstCall.parent.name, trieNode, doc, true);
+      }
+    };
+
+    /** Walks up the parent chain from one identifier occurrence, descending
+     * through the trie for each property access, until the use terminates:
+     * - leaf access: mark the leaf used
+     * - aliased into a new binding or assignment: track that binding
+     * - escapes (returned, passed to a call, spread): mark the subtree used
+     */
+    const walkUseChain = (start: ts.Identifier, entry: Entry) => {
+      const doc = entry.doc;
+      let cursor: ts.Node = start;
+      let trieNode = entry.node;
+      // True while the cursor still IS the tracked value (only accesses and
+      // value-preserving wrappers in between). Once the value is folded into
+      // a larger expression (`a.b && ...`, `cond ? a.b : ...`) it no longer
+      // escapes through calls/spreads as-is.
+      let pureChain = true;
+
+      while (true) {
+        const parent: ts.Node | undefined = cursor.parent;
+        if (!parent) break;
+
+        if (ts.isPropertyAccessExpression(parent)) {
+          if (parent.expression !== cursor) break;
+          const name = parent.name.text;
+          const grand = parent.parent;
+          if (ts.isCallExpression(grand) && grand.expression === parent) {
+            if (name === 'at') {
+              // `.at(...)` is an array element pass-through
+              cursor = grand;
+              continue;
+            } else if (arrayMethods.has(name)) {
+              handleArrayChain(grand, name, trieNode, doc);
+              doc.accessCount++;
+              return;
+            }
+          }
+          trieNode = trieNode.children.get(name) || trieNode;
+          cursor = parent;
+          continue;
+        }
+
+        if (ts.isElementAccessExpression(parent)) {
+          if (parent.expression !== cursor) break;
+          if (ts.isStringLiteral(parent.argumentExpression)) {
+            trieNode =
+              trieNode.children.get(parent.argumentExpression.text) || trieNode;
+          }
+          // Numeric/computed element access is an array pass-through
+          cursor = parent;
+          continue;
+        }
+
+        if (
+          ts.isNonNullExpression(parent) ||
+          ts.isParenthesizedExpression(parent) ||
+          ts.isAsExpression(parent) ||
+          ts.isAwaitExpression(parent) ||
+          (ts.isSatisfiesExpression && ts.isSatisfiesExpression(parent))
+        ) {
+          cursor = parent;
+          continue;
+        }
+
+        if (ts.isBinaryExpression(parent)) {
+          if (parent.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+            // Write target of an assignment, not a use
+            if (parent.left === cursor) return;
+            if (ts.isIdentifier(parent.left)) {
+              // `existing = result.data.pokemon` aliases like a declaration
+              addEntry(
+                checker.getSymbolAtLocation(parent.left),
+                trieNode,
+                doc,
+                false
+              );
+              doc.accessCount++;
+              return;
+            }
+            if (pureChain) {
+              // The value escapes into a property/element write
+              if (trieNode.isLeaf) trieNode.used = true;
+              markSubtreeUsed(trieNode);
+              doc.accessCount++;
+              return;
+            }
+            break;
+          }
+          pureChain = false;
+          cursor = parent;
+          continue;
+        }
+
+        if (ts.isConditionalExpression(parent)) {
+          // The branches carry the value onward, the condition is only a test
+          if (parent.condition === cursor) break;
+          pureChain = false;
+          cursor = parent;
+          continue;
+        }
+
+        if (ts.isVariableDeclaration(parent)) {
+          trackBinding(parent.name, trieNode, doc, false);
+          return;
+        }
+
+        if (ts.isForOfStatement(parent) && parent.expression === cursor) {
+          // `for (const p of result.data.pokemons)`: the loop binding holds
+          // an element of the iterated value
+          if (ts.isVariableDeclarationList(parent.initializer)) {
+            for (const declaration of parent.initializer.declarations) {
+              trackBinding(declaration.name, trieNode, doc, false);
+            }
+          } else if (ts.isIdentifier(parent.initializer)) {
+            addEntry(
+              checker.getSymbolAtLocation(parent.initializer),
+              trieNode,
+              doc,
+              false
+            );
+          }
+          doc.accessCount++;
+          return;
+        }
+
+        if (
+          ts.isReturnStatement(parent) ||
+          (ts.isArrowFunction(parent) && parent.body === cursor)
+        ) {
+          // The data escapes through a return; everything below the current
+          // position has to be considered used — unless we're returning from
+          // an array-method callback, which stays within the chain.
+          if (trieNode.isLeaf) trieNode.used = true;
+          if (!entry.suppressReturnBail) markSubtreeUsed(trieNode);
+          doc.accessCount++;
+          return;
+        }
+
+        if (ts.isCallExpression(parent) && parent.expression !== cursor) {
+          // Passed as an argument to an external function: when the tracked
+          // value itself escapes we consider its whole subtree used.
+          if (trieNode.isLeaf) trieNode.used = true;
+          if (pureChain) markSubtreeUsed(trieNode);
+          doc.accessCount++;
+          return;
+        }
+
+        if (
+          pureChain &&
+          (ts.isSpreadElement(parent) ||
+            ts.isSpreadAssignment(parent) ||
+            ts.isJsxSpreadAttribute(parent) ||
+            ts.isShorthandPropertyAssignment(parent) ||
+            (ts.isPropertyAssignment(parent) && parent.initializer === cursor))
+        ) {
+          // The tracked value escapes into an object/array/JSX spread
+          if (trieNode.isLeaf) trieNode.used = true;
+          markSubtreeUsed(trieNode);
+          doc.accessCount++;
+          return;
+        }
+
+        break;
+      }
+
+      // Terminal use without escape: a leaf read counts as usage, an
+      // intermediate read (e.g. passing `data.pokemon` to JSX) does not
+      // mark any fields but proves the result is consumed in this file.
+      if (trieNode.isLeaf) trieNode.used = true;
+      doc.accessCount++;
+    };
+
+    // Phase B3: seed the tracker for every document.
+    const declTypeCache = new Map<
+      ts.VariableDeclaration,
+      { type: ts.Type; tupleType?: ts.Type; dataType?: ts.Type }
+    >();
+    for (const state of docStates) {
+      const template = state.templateNode;
+      const graphqlCallNode = template.parent;
+
+      let docDeclaration: ts.VariableDeclaration | undefined;
+      let wrapper: ts.Node = graphqlCallNode.parent;
+      while (
+        ts.isParenthesizedExpression(wrapper) ||
+        ts.isAsExpression(wrapper) ||
+        ts.isNonNullExpression(wrapper) ||
+        (ts.isSatisfiesExpression && ts.isSatisfiesExpression(wrapper))
+      ) {
+        wrapper = wrapper.parent;
+      }
+      if (ts.isVariableDeclaration(wrapper)) docDeclaration = wrapper;
+
+      if (docDeclaration && ts.isIdentifier(docDeclaration.name)) {
+        // `const Doc = graphql(...)`: every value-occurrence of `Doc` that
+        // sits inside a variable declaration (`const [result] = useQuery(...)`)
+        // identifies the result binding of that query.
+        const docSymbol = checker.getSymbolAtLocation(docDeclaration.name);
+        if (docSymbol) {
+          const occurrences =
+            identifiersByName.get(docDeclaration.name.text) || [];
+          for (const occurrence of occurrences) {
+            if (getRefSymbol(occurrence) !== docSymbol) continue;
+            const declaration = getVariableDeclaration(occurrence);
+            if (!declaration || declaration === docDeclaration) continue;
+            trackBinding(declaration.name, state.root, state, false);
+          }
+        }
+      } else if (!docDeclaration) {
+        // Inline document (`useQuery({ query: graphql(...) })`): the
+        // enclosing declaration holds the query result directly.
+        const declaration = getVariableDeclaration(template);
+        if (declaration && ts.isIdentifier(declaration.name)) {
+          addEntry(
+            checker.getSymbolAtLocation(declaration.name),
+            state.root,
+            state,
+            false
+          );
+        }
+      }
+
+      // Type-driven fallback: find result bindings whose type derives from
+      // the document's data type (covers wrappers we can't see lexically,
+      // e.g. react-query's `useQuery({ queryFn })` patterns).
+      const dataType = resolveDataType(template, checker);
+      if (dataType) {
+        for (const declaration of callInitializedDecls) {
+          if (declaration === docDeclaration) continue;
+          let cached = declTypeCache.get(declaration);
+          if (!cached) {
+            const type = unwrapAbstractType(
+              checker.getTypeAtLocation(declaration.initializer!)
+            );
+            cached = { type };
+            if (type.flags & ts.TypeFlags.Object) {
+              const tupleProperty = type.getProperty('0');
+              if (tupleProperty) {
+                cached.tupleType = checker.getTypeOfSymbol(tupleProperty);
+              }
+              const dataProperty = (cached.tupleType || type).getProperty(
+                'data'
+              );
+              if (dataProperty) {
+                cached.dataType = unwrapAbstractType(
+                  checker.getTypeOfSymbol(dataProperty)
+                );
+              }
+            }
+            declTypeCache.set(declaration, cached);
+          }
+          if (
+            cached.type === dataType ||
+            cached.tupleType === dataType ||
+            cached.dataType === dataType
+          ) {
+            trackBinding(declaration.name, state.root, state, false);
+          }
+        }
+      }
+    }
+
+    // Phase B4: drain the worklist; entries enqueued while walking
+    // (aliases, destructured bindings, callback params) are picked up here.
+    for (let i = 0; i < queue.length; i++) {
+      const entry = queue[i];
+      const occurrences = identifiersByName.get(entry.symbol.name);
+      if (!occurrences) continue;
+      for (const occurrence of occurrences) {
+        if (getRefSymbol(occurrence) !== entry.symbol) continue;
+        walkUseChain(occurrence, entry);
+      }
+    }
+
+    // Phase C: report fields whose leaf was never read, aggregated on the
+    // parent field.
+    for (const state of docStates) {
+      if (!state.accessCount) continue;
+
+      const node = state.templateNode;
+      const fieldToLoc = state.fieldToLoc;
+      const unused = state.allPaths.filter(
+        path => !state.leafByPath.get(path)!.used
+      );
+
       const aggregatedUnusedFields = new Set<string>();
       const unusedChildren: { [key: string]: Set<string> } = {};
       const unusedFragmentLeaf = new Set<string>();
@@ -616,7 +751,7 @@ export const checkFieldUsageInFile = (
           messageText: `Field ${field} is not used.`,
         });
       });
-    });
+    }
   } catch (e: any) {
     console.error('[GraphQLSP]: ', e.message, e.stack);
   }

--- a/test/e2e/fixture-project-unused-fields/fixtures/multi-document.ts
+++ b/test/e2e/fixture-project-unused-fields/fixtures/multi-document.ts
@@ -1,0 +1,146 @@
+import { TypedDocumentNode } from '@graphql-typed-document-node/core';
+import { useQuery } from 'urql';
+import { graphql } from './gql';
+
+const PokemonQuery = graphql(`
+  query Po($id: ID!) {
+    pokemon(id: $id) {
+      id
+      fleeRate
+      ...pokemonFields
+      attacks {
+        special {
+          name
+          damage
+        }
+      }
+      weight {
+        minimum
+        maximum
+      }
+      name
+      __typename
+    }
+  }
+`);
+
+const PokemonsQuery = graphql(
+  `
+    query Pok {
+      pokemons {
+        name
+        maxCP
+        maxHP
+        fleeRate
+      }
+    }
+  `
+);
+
+export const PokemonFields = graphql(`
+  fragment pokemonFields on Pokemon {
+    id
+    name
+    attacks {
+      fast {
+        damage
+        name
+      }
+    }
+  }
+`);
+
+const toRow = (p: any) => p?.maxCP;
+
+export const AliasChains = () => {
+  const [result] = useQuery({
+    query: PokemonQuery,
+    variables: { id: '' },
+  });
+
+  const pokemon = result.data?.pokemon;
+  const weight = pokemon?.weight;
+  console.log(weight?.minimum);
+
+  return null;
+};
+
+export const NamedCallback = () => {
+  const [result] = useQuery({
+    query: PokemonsQuery,
+  });
+
+  const rows = result.data?.pokemons?.filter((p: any) => !!p?.name).map(toRow);
+  return rows;
+};
+
+export const Escape = (data: any) => {
+  const poke = useFragment(PokemonFields, data);
+  const obj = { list: poke };
+  return obj;
+};
+
+const ChainArgQuery = graphql(`
+  query ChainArg {
+    pokemons {
+      maxCP
+      maxHP
+    }
+  }
+`);
+
+const formatPokemons = (pokemons: any) => pokemons;
+
+export const ChainArg = () => {
+  const [result] = useQuery({ query: ChainArgQuery });
+  formatPokemons(result.data?.pokemons);
+  return null;
+};
+
+const ForOfQuery = graphql(`
+  query ForOf {
+    pokemons {
+      maxCP
+      maxHP
+      fleeRate
+    }
+  }
+`);
+
+export const ForOf = () => {
+  const [result] = useQuery({ query: ForOfQuery });
+  for (const p of result.data?.pokemons ?? []) {
+    console.log(p?.maxCP);
+  }
+  return null;
+};
+
+const AssignmentQuery = graphql(`
+  query Assignment {
+    pokemons {
+      maxCP
+      maxHP
+      fleeRate
+    }
+  }
+`);
+
+export const Assignment = (flag: boolean) => {
+  const [result] = useQuery({ query: AssignmentQuery });
+
+  let pokemons;
+  pokemons = result.data?.pokemons;
+  console.log(pokemons?.[0]?.maxCP);
+
+  const first = flag ? result.data?.pokemons?.[0] : null;
+  console.log(first?.maxHP);
+
+  return null;
+};
+
+export function useFragment<Type>(
+  _fragment: TypedDocumentNode<Type>,
+  data: any
+): Type {
+  return data;
+}

--- a/test/e2e/server.ts
+++ b/test/e2e/server.ts
@@ -1,5 +1,6 @@
 import { ChildProcess, fork } from 'node:child_process';
 import readline from 'node:readline';
+import path from 'node:path';
 import ts from 'typescript/lib/tsserverlibrary';
 
 type Command = `${ts.server.protocol.CommandTypes}`;
@@ -42,6 +43,12 @@ export class TSServer {
       try {
         const data = JSON.parse(line);
 
+        // tsserver emits normalized (forward-slash) paths; convert them to
+        // platform-native paths so tests can compare against path.join output
+        if (typeof data?.body?.file === 'string') {
+          data.body.file = path.normalize(data.body.file);
+        }
+
         this.responses.push(data);
 
         if (this.#resolvePromise && this.#waitFor?.(data)) {
@@ -78,8 +85,13 @@ export class TSServer {
   waitForResponse = (
     cb: (
       response: ts.server.protocol.Response | ts.server.protocol.Event
-    ) => boolean
+    ) => boolean,
+    checkExisting = false
   ) => {
+    if (checkExisting && this.responses.some(cb)) {
+      return Promise.resolve();
+    }
+
     this.#waitFor = cb;
     return new Promise<void>(resolve => {
       this.#resolvePromise = resolve;

--- a/test/e2e/unused-fieds.test.ts
+++ b/test/e2e/unused-fieds.test.ts
@@ -22,6 +22,7 @@ describe('unused fields', () => {
   const outfileFragment = path.join(projectPath, 'fragment.tsx');
   const outfilePropAccess = path.join(projectPath, 'property-access.tsx');
   const outfileChainedUsage = path.join(projectPath, 'chained-usage.ts');
+  const outfileMultiDocument = path.join(projectPath, 'multi-document.ts');
 
   let server: TSServer;
   beforeAll(async () => {
@@ -59,6 +60,11 @@ describe('unused fields', () => {
     } satisfies ts.server.protocol.OpenRequestArgs);
     server.sendCommand('open', {
       file: outfileChainedUsage,
+      fileContent: '// empty',
+      scriptKindName: 'TS',
+    } satisfies ts.server.protocol.OpenRequestArgs);
+    server.sendCommand('open', {
+      file: outfileMultiDocument,
       fileContent: '// empty',
       scriptKindName: 'TS',
     } satisfies ts.server.protocol.OpenRequestArgs);
@@ -114,6 +120,13 @@ describe('unused fields', () => {
             'utf-8'
           ),
         },
+        {
+          file: outfileMultiDocument,
+          fileContent: fs.readFileSync(
+            path.join(projectPath, 'fixtures/multi-document.ts'),
+            'utf-8'
+          ),
+        },
       ],
     } satisfies ts.server.protocol.UpdateOpenRequestArgs);
 
@@ -145,6 +158,10 @@ describe('unused fields', () => {
       file: outfileChainedUsage,
       tmpfile: outfileChainedUsage,
     } satisfies ts.server.protocol.SavetoRequestArgs);
+    server.sendCommand('saveto', {
+      file: outfileMultiDocument,
+      tmpfile: outfileMultiDocument,
+    } satisfies ts.server.protocol.SavetoRequestArgs);
   });
 
   afterAll(() => {
@@ -156,6 +173,7 @@ describe('unused fields', () => {
       fs.unlinkSync(outfileDestructuringFromStart);
       fs.unlinkSync(outfileBail);
       fs.unlinkSync(outfileChainedUsage);
+      fs.unlinkSync(outfileMultiDocument);
     } catch {}
   });
 
@@ -164,7 +182,8 @@ describe('unused fields', () => {
       e =>
         e.type === 'event' &&
         e.event === 'semanticDiag' &&
-        e.body?.file === outfileFragment
+        e.body?.file === outfileFragment,
+      true
     );
     const res = server.responses.filter(
       resp =>
@@ -196,7 +215,8 @@ describe('unused fields', () => {
       e =>
         e.type === 'event' &&
         e.event === 'semanticDiag' &&
-        e.body?.file === outfileFragmentDestructuring
+        e.body?.file === outfileFragmentDestructuring,
+      true
     );
     const res = server.responses.filter(
       resp =>
@@ -228,7 +248,8 @@ describe('unused fields', () => {
       e =>
         e.type === 'event' &&
         e.event === 'semanticDiag' &&
-        e.body?.file === outfilePropAccess
+        e.body?.file === outfilePropAccess,
+      true
     );
     const res = server.responses.filter(
       resp =>
@@ -295,6 +316,13 @@ describe('unused fields', () => {
   }, 30000);
 
   it('gives unused fields with destructuring', async () => {
+    await server.waitForResponse(
+      e =>
+        e.type === 'event' &&
+        e.event === 'semanticDiag' &&
+        e.body?.file === outfileDestructuring,
+      true
+    );
     const res = server.responses.filter(
       resp =>
         resp.type === 'event' &&
@@ -347,6 +375,13 @@ describe('unused fields', () => {
   }, 30000);
 
   it('gives unused fields with immedaite destructuring', async () => {
+    await server.waitForResponse(
+      e =>
+        e.type === 'event' &&
+        e.event === 'semanticDiag' &&
+        e.body?.file === outfileDestructuringFromStart,
+      true
+    );
     const res = server.responses.filter(
       resp =>
         resp.type === 'event' &&
@@ -399,6 +434,13 @@ describe('unused fields', () => {
   }, 30000);
 
   it('Bails unused fields when memo func is used', async () => {
+    await server.waitForResponse(
+      e =>
+        e.type === 'event' &&
+        e.event === 'semanticDiag' &&
+        e.body?.file === outfileBail,
+      true
+    );
     const res = server.responses.filter(
       resp =>
         resp.type === 'event' &&
@@ -424,7 +466,117 @@ describe('unused fields', () => {
     `);
   }, 30000);
 
+  it('Tracks multiple documents, alias chains and named callbacks in one file', async () => {
+    await server.waitForResponse(
+      e =>
+        e.type === 'event' &&
+        e.event === 'semanticDiag' &&
+        e.body?.file === outfileMultiDocument,
+      true
+    );
+    const res = server.responses.filter(
+      resp =>
+        resp.type === 'event' &&
+        resp.event === 'semanticDiag' &&
+        resp.body?.file === outfileMultiDocument
+    );
+    // The Pok document has no generated type (same as chained-usage.ts), so
+    // we only assert the unused-field diagnostics here.
+    const unusedFieldDiagnostics = res[0].body.diagnostics.filter(
+      (diagnostic: any) => diagnostic.code === 52005
+    );
+    expect(unusedFieldDiagnostics).toMatchInlineSnapshot(`
+      [
+        {
+          "category": "warning",
+          "code": 52005,
+          "end": {
+            "line": 7,
+            "offset": 12,
+          },
+          "start": {
+            "line": 7,
+            "offset": 5,
+          },
+          "text": "Field(s) 'pokemon.fleeRate', 'pokemon.name' are not used.",
+        },
+        {
+          "category": "warning",
+          "code": 52005,
+          "end": {
+            "line": 12,
+            "offset": 16,
+          },
+          "start": {
+            "line": 12,
+            "offset": 9,
+          },
+          "text": "Field(s) 'pokemon.attacks.special.name', 'pokemon.attacks.special.damage' are not used.",
+        },
+        {
+          "category": "warning",
+          "code": 52005,
+          "end": {
+            "line": 17,
+            "offset": 13,
+          },
+          "start": {
+            "line": 17,
+            "offset": 7,
+          },
+          "text": "Field(s) 'pokemon.weight.maximum' are not used.",
+        },
+        {
+          "category": "warning",
+          "code": 52005,
+          "end": {
+            "line": 30,
+            "offset": 15,
+          },
+          "start": {
+            "line": 30,
+            "offset": 7,
+          },
+          "text": "Field(s) 'pokemons.maxHP', 'pokemons.fleeRate' are not used.",
+        },
+        {
+          "category": "warning",
+          "code": 52005,
+          "end": {
+            "line": 102,
+            "offset": 13,
+          },
+          "start": {
+            "line": 102,
+            "offset": 5,
+          },
+          "text": "Field(s) 'pokemons.maxHP', 'pokemons.fleeRate' are not used.",
+        },
+        {
+          "category": "warning",
+          "code": 52005,
+          "end": {
+            "line": 120,
+            "offset": 13,
+          },
+          "start": {
+            "line": 120,
+            "offset": 5,
+          },
+          "text": "Field(s) 'pokemons.fleeRate' are not used.",
+        },
+      ]
+    `);
+  }, 30000);
+
   it('Finds field usage in chained call-expressions', async () => {
+    await server.waitForResponse(
+      e =>
+        e.type === 'event' &&
+        e.event === 'semanticDiag' &&
+        e.body?.file === outfileChainedUsage,
+      true
+    );
     const res = server.responses.filter(
       resp =>
         resp.type === 'event' &&


### PR DESCRIPTION
## Summary

Rewrites `trackFieldUsage` unused-field detection in `packages/graphqlsp/src/fieldUsage.ts` as a single-pass, symbol-driven analysis.

**Why:** the previous implementation issued a `getReferencesAtPosition` request per binding (each a whole-program search, called recursively for every destructured/aliased variable) and ran `checker.getSymbolsInScope` per reference — which enumerates the entire lexical scope including lib globals and forces type computation on candidates until a match. Combined with O(fields) `startsWith` string scans on every step, complexity was roughly O(bindings × references × scope size × program) per file.

**How it works now:**
- One AST walk indexes identifier occurrences by name (value positions only) and call-initialized declarations.
- Each document's selection set becomes a trie; bindings are tracked as `(symbol, trie position)` entries on a worklist. Property accesses descend the trie with a `Map.get`; wrapper keys (`data`, tuple indices) pass through as before.
- Binding resolution uses `checker.getSymbolAtLocation` identity (with the shorthand-property special case), so scoping is correct by construction and all documents in a file are served by a single pass.
- The react-query/urql fallback (tuple `[0]` / `.data` type matching) is preserved as a cached per-declaration type check.

**Expanded usage tracking** (reduces false positives; all quieter-direction):
- Pure access chains passed as call arguments (`format(data.pokemon.weight)`), spreads, and object-literal assignments mark their sub-selections as used. Chains folded into binaries/conditionals stay terminal, so boolean-gated accesses (`a?.b && a?.b.c`) keep their precision.
- `for (const p of result.data.pokemons)` tracks the loop binding like an array-method callback param.
- Assignments to existing variables and conditional-expression branches alias like variable declarations.

The public surface is unchanged: `checkFieldUsageInFile` signature, diagnostic code 52005, message format, and positions are identical — all pre-existing inline snapshots pass unmodified.

## Test changes

- `test/e2e/server.ts` normalizes tsserver event paths to platform-native form so the e2e suite runs on Windows (tsserver emits forward-slash paths; tests compare `path.join` output), and `waitForResponse` gained a `checkExisting` option.
- The unused-fields tests each wait for their own `semanticDiag` event instead of relying on event-arrival order, which the faster engine changed.
- New fixture `multi-document.ts` pins: multiple documents in one file (incl. same-named `result` bindings across components), two-step alias chains, named array-method callbacks (`.map(toRow)`), object-literal escape, chain-as-argument escape, `for...of`, and assignment/ternary aliasing.

## Notes for review

- Cross-file usage remains out of scope, matching the old `ref.fileName !== source.fileName` bail: exported documents only consumed in other files still produce no diagnostics (`accessCount` guard).
- `fn(a.b || fallback)` does not mark `a.b`'s subtree used — `||`/`??` currently mark the chain impure like other binaries. Can tighten if desired.
- On Windows, 4 unrelated e2e tests (tada/client-preset/combinations/multi-schema) fail on pre-existing CRLF end-position artifacts in GraphQL-validation diagnostics; verified identical on `main` with the old engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)