### PR TITLE
Treat ||/?? as value pass-throughs in unused-field tracking

### DIFF
--- a/.changeset/polite-mangos-wave.md
+++ b/.changeset/polite-mangos-wave.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Treat `||` and `??` as value pass-throughs in unused-field tracking: `fn(a.b || fallback)` now marks `a.b`'s sub-selections as used, like other escapes of an access chain. `&&` keeps its guard semantics, so `a?.b && a?.b.c` retains leaf-level precision.

--- a/packages/graphqlsp/src/fieldUsage.ts
+++ b/packages/graphqlsp/src/fieldUsage.ts
@@ -507,7 +507,16 @@ export const checkFieldUsageInFile = (
             }
             break;
           }
-          pureChain = false;
+          // `||`/`??` pass the operand's value through to the result
+          // (`fn(a.b || fallback)` still escapes `a.b`), so they keep the
+          // chain pure. `&&` and the rest fold the value into a test or a
+          // derived value: `a?.b && a?.b.c` keeps its leaf precision.
+          if (
+            parent.operatorToken.kind !== ts.SyntaxKind.BarBarToken &&
+            parent.operatorToken.kind !== ts.SyntaxKind.QuestionQuestionToken
+          ) {
+            pureChain = false;
+          }
           cursor = parent;
           continue;
         }

--- a/test/e2e/fixture-project-unused-fields/fixtures/multi-document.ts
+++ b/test/e2e/fixture-project-unused-fields/fixtures/multi-document.ts
@@ -144,3 +144,37 @@ export function useFragment<Type>(
 ): Type {
   return data;
 }
+
+const OrFallbackQuery = graphql(`
+  query OrFallback {
+    pokemons {
+      maxCP
+      maxHP
+      fleeRate
+    }
+  }
+`);
+
+export const OrFallback = () => {
+  const [result] = useQuery({ query: OrFallbackQuery });
+  // ||/?? pass the value through, so the chain still escapes into the call
+  formatPokemons(result.data?.pokemons || []);
+  return null;
+};
+
+const GuardQuery = graphql(`
+  query Guard {
+    pokemons {
+      maxCP
+      maxHP
+    }
+  }
+`);
+
+export const Guard = (flag: boolean) => {
+  const [result] = useQuery({ query: GuardQuery });
+  // && folds the value into a test, so this is not an escape of the chain
+  formatPokemons(flag && result.data?.pokemons);
+  console.log(result.data?.pokemons?.[0]?.maxCP ?? 0);
+  return null;
+};

--- a/test/e2e/unused-fieds.test.ts
+++ b/test/e2e/unused-fieds.test.ts
@@ -565,6 +565,19 @@ describe('unused fields', () => {
           },
           "text": "Field(s) 'pokemons.fleeRate' are not used.",
         },
+        {
+          "category": "warning",
+          "code": 52005,
+          "end": {
+            "line": 167,
+            "offset": 13,
+          },
+          "start": {
+            "line": 167,
+            "offset": 5,
+          },
+          "text": "Field(s) 'pokemons.maxHP' are not used.",
+        },
       ]
     `);
   }, 30000);


### PR DESCRIPTION
## Summary

Follow-up to #393, addressing the review note: *"`fn(a.b || fallback)` does not mark `a.b`'s subtree used — `||`/`??` currently mark the chain impure like other binaries. Can tighten if desired."*

In `walkUseChain`, every non-assignment binary operator marked the access chain impure, so a chain folded into `||`/`??` no longer counted as an escape when passed to a call, returned, or spread. But unlike `&&`, comparisons, or arithmetic, `||` and `??` pass the operand's value through to the result — `fn(a.b || fallback)` hands `a.b` itself to `fn`. These two operators now keep the chain pure, so the sub-selections are marked used (the quieter direction, fewer false positives).

`&&` intentionally keeps its guard semantics: it folds the value into a test, so `a?.b && a?.b.c` retains leaf-level precision and `fn(flag && a.b)` is still not treated as an escape. A chain that is already impure stays impure across `||`/`??` — the change only skips setting the flag, it never resets it.

## Test changes

Two new components in the `multi-document.ts` fixture pin both sides of the boundary:

- `OrFallback`: `formatPokemons(result.data?.pokemons || [])` produces no unused-field diagnostics.
- `Guard`: `formatPokemons(flag && result.data?.pokemons)` is not an escape, so its unread `pokemons.maxHP` still reports (new inline-snapshot entry).

## Notes for review

- Verified with the e2e suite on Windows: all unused-fields tests pass; the only failures are the 4 pre-existing CRLF end-position artifacts (tada/client-preset/combinations/multi-schema) that fail identically on `main`.
- `||=`/`??=` compound assignments are untouched — they still mark the chain impure like before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
