### PR TITLE
fix: Reduce co-located fragments warnings by excluding referenced fragments

### DIFF
--- a/.changeset/fuzzy-snakes-hope.md
+++ b/.changeset/fuzzy-snakes-hope.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Mute co-located fragment warnings, when fragments are directly referenced.

--- a/packages/graphqlsp/src/ast/checks.ts
+++ b/packages/graphqlsp/src/ast/checks.ts
@@ -171,13 +171,3 @@ export const getSchemaName = (
     return null;
   });
 };
-
-/** Checks if node is a maskFragments() call */
-export const isMaskFragmentsCall = (
-  node: ts.Node
-): node is ts.CallExpression => {
-  if (!ts.isCallExpression(node)) return false;
-  if (!ts.isIdentifier(node.expression)) return false;
-  // Only checks function name, not whether it's from gql.tada
-  return node.expression.escapedText === 'maskFragments';
-};

--- a/packages/graphqlsp/src/ast/index.ts
+++ b/packages/graphqlsp/src/ast/index.ts
@@ -356,21 +356,6 @@ export function findAllImports(
   return sourceFile.statements.filter(ts.isImportDeclaration);
 }
 
-export function findAllMaskFragmentsCalls(
-  sourceFile: ts.SourceFile
-): Array<ts.CallExpression> {
-  const result: Array<ts.CallExpression> = [];
-
-  function find(node: ts.Node): void {
-    if (checks.isMaskFragmentsCall(node)) {
-      result.push(node);
-    }
-    ts.forEachChild(node, find);
-  }
-  find(sourceFile);
-  return result;
-}
-
 export function bubbleUpTemplate(node: ts.Node): ts.Node {
   while (
     ts.isNoSubstitutionTemplateLiteral(node) ||

--- a/packages/graphqlsp/src/diagnostics.ts
+++ b/packages/graphqlsp/src/diagnostics.ts
@@ -16,7 +16,6 @@ import {
   findAllImports,
   findAllPersistedCallExpressions,
   findAllTaggedTemplateNodes,
-  findAllMaskFragmentsCalls,
   getSource,
   unrollFragment,
 } from './ast';
@@ -464,25 +463,9 @@ export function getGraphQLDiagnostics(
       } catch (e) {}
     });
 
-    // check for maskFragments() calls
-    const maskFragmentsCalls = findAllMaskFragmentsCalls(source);
-    maskFragmentsCalls.forEach(call => {
-      const firstArg = call.arguments[0];
-      if (!firstArg) return;
-
-      // Handle array of fragments: maskFragments([Fragment1, Fragment2], data)
-      if (ts.isArrayLiteralExpression(firstArg)) {
-        firstArg.elements.forEach(element => {
-          if (ts.isIdentifier(element)) {
-            const fragmentDefs = unrollFragment(element, info, typeChecker);
-            fragmentDefs.forEach(def => usedFragments.add(def.name.value));
-          }
-        });
-      }
-    });
-
-    // A fragment referenced directly (as a type/value) rather than declared in a
-    // fragment-reference array isn't meant to be spread here, so don't flag it.
+    // A fragment referenced directly (as a type/value, or via maskFragments())
+    // rather than declared in a fragment-reference array isn't meant to be
+    // spread here, so don't flag it.
     const directlyUsedFragments = getDirectlyUsedFragments(
       source,
       nodes,

--- a/packages/graphqlsp/src/diagnostics.ts
+++ b/packages/graphqlsp/src/diagnostics.ts
@@ -13,12 +13,14 @@ import { print } from '@0no-co/graphql.web';
 
 import {
   findAllCallExpressions,
+  findAllImports,
   findAllPersistedCallExpressions,
   findAllTaggedTemplateNodes,
   findAllMaskFragmentsCalls,
   getSource,
   unrollFragment,
 } from './ast';
+import { getValueOfIdentifier } from './ast/declaration';
 import { resolveTemplate } from './ast/resolve';
 import { templates } from './ast/templates';
 import { UNUSED_FIELD_CODE, checkFieldUsageInFile } from './fieldUsage';
@@ -225,6 +227,7 @@ export function getGraphQLDiagnostics(
     nodes: {
       node: ts.StringLiteralLike | ts.TaggedTemplateExpression;
       schema: string | null;
+      tadaFragmentRefs?: readonly ts.Identifier[] | null;
     }[];
   if (isCallExpression) {
     const result = findAllCallExpressions(source, info);
@@ -478,6 +481,14 @@ export function getGraphQLDiagnostics(
       }
     });
 
+    // A fragment referenced directly (as a type/value) rather than declared in a
+    // fragment-reference array isn't meant to be spread here, so don't flag it.
+    const directlyUsedFragments = getDirectlyUsedFragments(
+      source,
+      nodes,
+      typeChecker
+    );
+
     Object.keys(moduleSpecifierToFragments).forEach(moduleSpecifier => {
       const {
         fragments: fragmentNames,
@@ -485,7 +496,11 @@ export function getGraphQLDiagnostics(
         length,
       } = moduleSpecifierToFragments[moduleSpecifier]!;
       const missingFragments = Array.from(
-        new Set(fragmentNames.filter(x => !usedFragments.has(x)))
+        new Set(
+          fragmentNames.filter(
+            x => !usedFragments.has(x) && !directlyUsedFragments.has(x)
+          )
+        )
       );
       if (missingFragments.length) {
         fragmentDiagnostics.push({
@@ -507,6 +522,100 @@ export function getGraphQLDiagnostics(
   }
 }
 
+/** Resolves the fragment name(s) defined directly by an identifier's `graphql()`
+ * document, excluding fragments it only composes via its reference array. */
+function getFragmentNamesForIdentifier(
+  identifier: ts.Identifier,
+  checker: ts.TypeChecker
+): string[] {
+  const value = getValueOfIdentifier(identifier, checker);
+  if (!value || !ts.isCallExpression(value)) return [];
+  const documentArg = value.arguments[0];
+  if (!documentArg || !ts.isStringLiteralLike(documentArg)) return [];
+  try {
+    const parsed = parse(documentArg.getText().slice(1, -1), {
+      noLocation: true,
+    });
+    return parsed.definitions
+      .filter(
+        (definition): definition is FragmentDefinitionNode =>
+          definition.kind === Kind.FRAGMENT_DEFINITION
+      )
+      .map(definition => definition.name.value);
+  } catch (e) {
+    return [];
+  }
+}
+
+/** Collects fragment names whose imported binding is referenced outside both its
+ * import and any `graphql()` fragment-reference array — i.e. used directly (as a
+ * type, an unmasking-call argument, or a re-export) and so not meant to be
+ * spread here. Bindings only in a reference array, or never referenced, are left
+ * to warn. */
+function getDirectlyUsedFragments(
+  source: ts.SourceFile,
+  nodes: Array<{ tadaFragmentRefs?: readonly ts.Identifier[] | null }>,
+  typeChecker: ts.TypeChecker | undefined
+): Set<string> {
+  const directlyUsedFragments = new Set<string>();
+  if (!typeChecker) return directlyUsedFragments;
+
+  // A reference here is an explicit co-location declaration, not a direct use.
+  const fragmentRefIdentifiers = new Set<ts.Node>();
+  nodes.forEach(({ tadaFragmentRefs }) => {
+    if (tadaFragmentRefs)
+      tadaFragmentRefs.forEach(identifier =>
+        fragmentRefIdentifiers.add(identifier)
+      );
+  });
+
+  // Index occurrences by symbol once, rather than re-walking per import.
+  const occurrencesBySymbol = new Map<ts.Symbol, ts.Identifier[]>();
+  const visit = (node: ts.Node): void => {
+    if (ts.isIdentifier(node)) {
+      const symbol = typeChecker.getSymbolAtLocation(node);
+      if (symbol) {
+        const existing = occurrencesBySymbol.get(symbol);
+        if (existing) existing.push(node);
+        else occurrencesBySymbol.set(symbol, [node]);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+
+  const bindings: ts.Identifier[] = [];
+  findAllImports(source).forEach(imp => {
+    const clause = imp.importClause;
+    if (!clause) return;
+    if (clause.name) bindings.push(clause.name);
+    const namedBindings = clause.namedBindings;
+    if (namedBindings) {
+      if (ts.isNamespaceImport(namedBindings)) {
+        bindings.push(namedBindings.name);
+      } else {
+        namedBindings.elements.forEach(element => bindings.push(element.name));
+      }
+    }
+  });
+
+  bindings.forEach(binding => {
+    const symbol = typeChecker.getSymbolAtLocation(binding);
+    if (!symbol) return;
+    const occurrences = occurrencesBySymbol.get(symbol) || [];
+    const usedDirectly = occurrences.some(
+      identifier =>
+        identifier !== binding && !fragmentRefIdentifiers.has(identifier)
+    );
+    if (!usedDirectly) return;
+    getFragmentNamesForIdentifier(binding, typeChecker).forEach(name =>
+      directlyUsedFragments.add(name)
+    );
+  });
+
+  return directlyUsedFragments;
+}
+
 const runDiagnostics = (
   source: ts.SourceFile,
   {
@@ -516,7 +625,7 @@ const runDiagnostics = (
     nodes: {
       node: ts.TaggedTemplateExpression | ts.StringLiteralLike;
       schema: string | null;
-      tadaFragmentRefs?: readonly ts.Identifier[];
+      tadaFragmentRefs?: readonly ts.Identifier[] | null;
     }[];
     fragments: FragmentDefinitionNode[];
   },
@@ -569,7 +678,10 @@ const runDiagnostics = (
       const endPosition = startingPosition + node.getText().length;
       let docFragments = [...fragments];
 
-      if (originalNode.tadaFragmentRefs !== undefined) {
+      if (
+        originalNode.tadaFragmentRefs !== undefined &&
+        originalNode.tadaFragmentRefs !== null
+      ) {
         const fragmentNames = new Set<string>();
         for (const identifier of originalNode.tadaFragmentRefs) {
           const unrolled = unrollFragment(identifier, info, typeChecker);

--- a/test/e2e/fixture-project-tada/fixtures/used-fragment-direct.ts
+++ b/test/e2e/fixture-project-tada/fixtures/used-fragment-direct.ts
@@ -1,0 +1,15 @@
+import { graphql, type FragmentOf } from './graphql';
+import { PokemonFields } from './fragment';
+
+const x = graphql(`
+  query Pok($limit: Int!) {
+    pokemons(limit: $limit) {
+      id
+      name
+    }
+  }
+`);
+
+export const render = (pokemon: FragmentOf<typeof PokemonFields>) => pokemon;
+
+console.log(x);

--- a/test/e2e/tada.test.ts
+++ b/test/e2e/tada.test.ts
@@ -16,6 +16,10 @@ describe('Fragment + operations', () => {
     projectPath,
     'used-fragment-mask.ts'
   );
+  const outfileUsedFragmentDirect = path.join(
+    projectPath,
+    'used-fragment-direct.ts'
+  );
   const outfileCombinations = path.join(projectPath, 'fragment.ts');
 
   let server: TSServer;
@@ -44,6 +48,11 @@ describe('Fragment + operations', () => {
     } satisfies ts.server.protocol.OpenRequestArgs);
     server.sendCommand('open', {
       file: outfileUsedFragmentMask,
+      fileContent: '// empty',
+      scriptKindName: 'TS',
+    } satisfies ts.server.protocol.OpenRequestArgs);
+    server.sendCommand('open', {
+      file: outfileUsedFragmentDirect,
       fileContent: '// empty',
       scriptKindName: 'TS',
     } satisfies ts.server.protocol.OpenRequestArgs);
@@ -85,6 +94,13 @@ describe('Fragment + operations', () => {
             'utf-8'
           ),
         },
+        {
+          file: outfileUsedFragmentDirect,
+          fileContent: fs.readFileSync(
+            path.join(projectPath, 'fixtures/used-fragment-direct.ts'),
+            'utf-8'
+          ),
+        },
       ],
     } satisfies ts.server.protocol.UpdateOpenRequestArgs);
 
@@ -108,12 +124,17 @@ describe('Fragment + operations', () => {
       file: outfileUsedFragmentMask,
       tmpfile: outfileUsedFragmentMask,
     } satisfies ts.server.protocol.SavetoRequestArgs);
+    server.sendCommand('saveto', {
+      file: outfileUsedFragmentDirect,
+      tmpfile: outfileUsedFragmentDirect,
+    } satisfies ts.server.protocol.SavetoRequestArgs);
   });
 
   afterAll(() => {
     try {
       fs.unlinkSync(outfileUnusedFragment);
       fs.unlinkSync(outfileUsedFragmentMask);
+      fs.unlinkSync(outfileUsedFragmentDirect);
       fs.unlinkSync(outfileCombinations);
       fs.unlinkSync(outfileCombo);
       fs.unlinkSync(outfileTypeCondition);
@@ -427,6 +448,28 @@ List out all Pokémon, optionally in pages`
         resp.body?.file === outfileUsedFragmentMask
     );
     // Should have no diagnostics about unused fragments since maskFragments uses them
+    expect(res[0].body.diagnostics).toMatchInlineSnapshot(`[]`);
+  }, 30000);
+
+  it('should not warn about unused fragments when the fragment is used directly (not co-located)', async () => {
+    server.sendCommand('saveto', {
+      file: outfileUsedFragmentDirect,
+      tmpfile: outfileUsedFragmentDirect,
+    } satisfies ts.server.protocol.SavetoRequestArgs);
+
+    await server.waitForResponse(
+      e =>
+        e.type === 'event' &&
+        e.event === 'semanticDiag' &&
+        e.body?.file === outfileUsedFragmentDirect
+    );
+
+    const res = server.responses.filter(
+      resp =>
+        resp.type === 'event' &&
+        resp.event === 'semanticDiag' &&
+        resp.body?.file === outfileUsedFragmentDirect
+    );
     expect(res[0].body.diagnostics).toMatchInlineSnapshot(`[]`);
   }, 30000);
 


### PR DESCRIPTION
## Summary

Today, the co-located fragments warning is quite aggressive when the co-location pattern isn't followed. Fragments that don't follow these patterns are often referenced directly, or only used as typed, but still referenced.

We can try not treating this rule as a generic "co-location enforcer" and instead narrow its use to the original intention: "warn when co-location is intended in imported module, but not to be used or forgotten in importer." In other words, when all exported fragments of a module are referenced, we exclude them from the warning and mute it.

When a user has `FragmentOf<typeof Frag>` on an import, for example, or `useFragment`, this counts as a use and we don't issue this warning.

## Set of changes

- Exclude referenced fragments from co-location check/warning
- Remove redundant `maskFragments` check (as it now counts as reference already)
- Add E2E coverage