### PR TITLE
chore: Update `@gql.tada/internal` and preserve output file headers

### DIFF
--- a/.changeset/purple-ducks-melt.md
+++ b/.changeset/purple-ducks-melt.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Update `@gql.tada/internal` and preserve introspection output file header

--- a/packages/example-tada/package.json
+++ b/packages/example-tada/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@graphql-typed-document-node/core": "^3.2.0",
-    "gql.tada": "1.10.0",
+    "gql.tada": "^1.11.0",
     "@urql/core": "^3.0.0",
     "graphql": "^16.8.1",
     "urql": "^4.0.6"

--- a/packages/graphqlsp/package.json
+++ b/packages/graphqlsp/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@gql.tada/internal": "^1.1.0",
+    "@gql.tada/internal": "^1.2.0",
     "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
   },
   "peerDependencies": {

--- a/packages/graphqlsp/src/fieldUsage.ts
+++ b/packages/graphqlsp/src/fieldUsage.ts
@@ -170,7 +170,7 @@ export const checkFieldUsageInFile = (
             const path = inProgress.length
               ? `${inProgress.join('.')}.${alias}`
               : alias;
-            const parent = trieStack[trieStack.length - 1];
+            const parent = trieStack[trieStack.length - 1]!;
 
             if (
               !fieldNode.selectionSet &&
@@ -693,7 +693,7 @@ export const checkFieldUsageInFile = (
     // Phase B4: drain the worklist; entries enqueued while walking
     // (aliases, destructured bindings, callback params) are picked up here.
     for (let i = 0; i < queue.length; i++) {
-      const entry = queue[i];
+      const entry = queue[i]!;
       const occurrences = identifiersByName.get(entry.symbol.name);
       if (!occurrences) continue;
       for (const occurrence of occurrences) {

--- a/packages/graphqlsp/src/graphql/getSchema.ts
+++ b/packages/graphqlsp/src/graphql/getSchema.ts
@@ -13,6 +13,7 @@ import {
   loadRef,
   minifyIntrospection,
   outputIntrospectionFile,
+  extractIntrospectionHeader,
   parseConfig,
   resolveTypeScriptRootDir,
 } from '@gql.tada/internal';
@@ -78,12 +79,6 @@ async function saveTadaIntrospection(
   logger: Logger
 ) {
   try {
-    const minified = minifyIntrospection(introspection);
-    const contents = outputIntrospectionFile(minified, {
-      fileType: tadaOutputLocation,
-      shouldPreprocess: !disablePreprocessing,
-    });
-
     let output = tadaOutputLocation;
     if (await statFile(output, stat => stat.isDirectory())) {
       output = path.join(output, 'introspection.d.ts');
@@ -93,6 +88,16 @@ async function saveTadaIntrospection(
         output = path.join(output, 'introspection.d.ts');
       }
     }
+
+    const existing = await fs.readFile(output, 'utf8').catch(() => undefined);
+    const minified = minifyIntrospection(introspection);
+    const contents = outputIntrospectionFile(minified, {
+      fileType: tadaOutputLocation,
+      shouldPreprocess: !disablePreprocessing,
+      preamble: existing
+        ? extractIntrospectionHeader(existing) || undefined
+        : undefined,
+    });
 
     await swapWrite(output, contents);
     errors.write.delete(tadaOutputLocation);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,7 +124,7 @@ importers:
         version: link:../graphqlsp
       '@graphql-codegen/cli':
         specifier: ^5.0.0
-        version: 5.0.0(@types/node@18.15.11)(enquirer@2.4.1)(graphql@16.8.1)(typescript@5.3.3)
+        version: 5.0.0(@types/node@18.19.130)(enquirer@2.4.1)(graphql@16.8.1)(typescript@5.3.3)
       '@graphql-codegen/client-preset':
         specifier: ^4.1.0
         version: 4.1.0(graphql@16.8.1)
@@ -133,7 +133,7 @@ importers:
         version: 18.2.45
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@types/node@18.15.11)(typescript@5.3.3)
+        version: 10.9.1(@types/node@18.19.130)(typescript@5.3.3)
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
@@ -147,8 +147,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0(graphql@16.8.1)
       gql.tada:
-        specifier: 1.10.0
-        version: 1.10.0(graphql@16.8.1)(typescript@5.3.3)
+        specifier: ^1.11.0
+        version: 1.11.0(graphql@16.8.1)(typescript@5.3.3)
       graphql:
         specifier: ^16.8.1
         version: 16.8.1
@@ -161,7 +161,7 @@ importers:
         version: link:../graphqlsp
       '@graphql-codegen/cli':
         specifier: ^5.0.0
-        version: 5.0.0(@types/node@18.15.11)(enquirer@2.4.1)(graphql@16.8.1)(typescript@5.3.3)
+        version: 5.0.0(@types/node@18.19.130)(enquirer@2.4.1)(graphql@16.8.1)(typescript@5.3.3)
       '@graphql-codegen/client-preset':
         specifier: ^4.1.0
         version: 4.1.0(graphql@16.8.1)
@@ -170,7 +170,7 @@ importers:
         version: 18.2.45
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@types/node@18.15.11)(typescript@5.3.3)
+        version: 10.9.1(@types/node@18.19.130)(typescript@5.3.3)
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
@@ -178,8 +178,8 @@ importers:
   packages/graphqlsp:
     dependencies:
       '@gql.tada/internal':
-        specifier: ^1.1.0
-        version: 1.1.0(graphql@16.8.1)(typescript@5.3.3)
+        specifier: ^1.2.0
+        version: 1.2.0(graphql@16.8.1)(typescript@5.3.3)
       graphql:
         specifier: ^15.5.0 || ^16.0.0 || ^17.0.0
         version: 16.8.1
@@ -286,8 +286,8 @@ importers:
         specifier: ^4.0.4
         version: 4.0.4(graphql@16.8.1)
       gql.tada:
-        specifier: ^1.10.0
-        version: 1.10.0(graphql@16.8.1)(typescript@5.3.3)
+        specifier: ^1.11.0
+        version: 1.11.0(graphql@16.8.1)(typescript@5.3.3)
       graphql:
         specifier: ^16.0.0
         version: 16.8.1
@@ -308,8 +308,8 @@ importers:
         specifier: ^4.0.4
         version: 4.0.4(graphql@16.8.1)
       gql.tada:
-        specifier: 1.10.0
-        version: 1.10.0(graphql@16.8.1)(typescript@5.3.3)
+        specifier: ^1.11.0
+        version: 1.11.0(graphql@16.8.1)(typescript@5.3.3)
       graphql:
         specifier: ^16.0.0
         version: 16.8.1
@@ -361,8 +361,8 @@ packages:
       graphql:
         optional: true
 
-  '@0no-co/graphqlsp@1.16.0':
-    resolution: {integrity: sha512-LysXpfIIjU3tEwhfNP0pMyvQY2pZ6C7Pfi/+LBwnO0qInoEeC/4YcwwUYcbZGS4dfR5+QCFjADENb4mHfeGZjg==}
+  '@0no-co/graphqlsp@1.17.1':
+    resolution: {integrity: sha512-grt2Nq6eBkFziaxYWrGcKQjuibTIX8df9kgn7KSKAFnI/mUajPhxBanbnIgQX8m1oEOEFf0OXz4vb2exOKro/A==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
       typescript: ^5.3.3
@@ -734,9 +734,9 @@ packages:
   '@fastify/busboy@3.2.0':
     resolution: {integrity: sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==}
 
-  '@gql.tada/cli-utils@1.8.0':
-    resolution: {integrity: sha512-0A8eq74VOG4XleSwgRXhZtKduRckIxzSdTZ3LAi3AN6wtHhPJ7dXB4FMMWHGzqGSoBKAonPdWM7sIMUmnnTqQw==}
-    version: 1.8.0
+  '@gql.tada/cli-utils@1.9.0':
+    resolution: {integrity: sha512-sTlFYC4dFxbJtLwmA43qzt/fo5SHJ4PWFmj45ILNuslZ/0E3Wpb436ll63G5EBFG+Dx/SWMe2S+epVw9rchQVA==}
+    version: 1.9.0
     peerDependencies:
       '@0no-co/graphqlsp': ^1.16.0
       '@gql.tada/svelte-support': 1.0.3
@@ -749,8 +749,8 @@ packages:
       '@gql.tada/vue-support':
         optional: true
 
-  '@gql.tada/internal@1.1.0':
-    resolution: {integrity: sha512-ZfSypAi6L0V9BzhTKnSQ+8FL460hArq/puDkotKuaNi8Vvfy7J3tOearfQatyfUrSiZ/oW99rxyjUfUJiHJz8Q==}
+  '@gql.tada/internal@1.2.0':
+    resolution: {integrity: sha512-mbrWlSLNMCMuP7uGFm4EGFJ0oU1XqzUqykAqQ4emVLUvuERKB6Vhb3KoWdSqSCCBKm7G3WcYCYgFbaMUUMNshw==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
       typescript: ^5.3.3
@@ -1402,6 +1402,9 @@ packages:
   '@types/node@18.15.11':
     resolution: {integrity: sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==}
 
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
@@ -1958,8 +1961,8 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
-  gql.tada@1.10.0:
-    resolution: {integrity: sha512-W4U0qU2RRs3c2938RRnljmUFa5IGaLOJZUZ10USXDrpQjXmzimTOiIwDBzxEJN6/UTIpIsXFewK9mBQA+6RUlA==}
+  gql.tada@1.11.0:
+    resolution: {integrity: sha512-QmBB7HTPBH3fBHdAEBBbq8N/1tyq9abdINply2rSUW1FVvZJ/b/jOD8esKVHh+JEajCCtfjGl0Kx2RyvXJFNCQ==}
     hasBin: true
     peerDependencies:
       typescript: ^5.3.3
@@ -2917,6 +2920,9 @@ packages:
     resolution: {integrity: sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==}
     engines: {node: '>=0.10.0'}
 
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
   undici@5.29.0:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
     engines: {node: '>=14.0'}
@@ -3145,15 +3151,15 @@ snapshots:
     optionalDependencies:
       graphql: 16.8.1
 
-  '@0no-co/graphqlsp@1.16.0(graphql@16.8.1)(typescript@5.3.3)':
+  '@0no-co/graphqlsp@1.17.1(graphql@16.8.1)(typescript@5.3.3)':
     dependencies:
-      '@gql.tada/internal': 1.1.0(graphql@16.8.1)(typescript@5.3.3)
+      '@gql.tada/internal': 1.2.0(graphql@16.8.1)(typescript@5.3.3)
       graphql: 16.8.1
       typescript: 5.3.3
 
   '@0no-co/graphqlsp@file:packages/graphqlsp(graphql@16.8.1)(typescript@5.3.3)':
     dependencies:
-      '@gql.tada/internal': 1.1.0(graphql@16.8.1)(typescript@5.3.3)
+      '@gql.tada/internal': 1.2.0(graphql@16.8.1)(typescript@5.3.3)
       graphql: 16.8.1
       typescript: 5.3.3
 
@@ -3610,14 +3616,14 @@ snapshots:
 
   '@fastify/busboy@3.2.0': {}
 
-  '@gql.tada/cli-utils@1.8.0(@0no-co/graphqlsp@file:packages/graphqlsp(graphql@16.8.1)(typescript@5.3.3))(graphql@16.8.1)(typescript@5.3.3)':
+  '@gql.tada/cli-utils@1.9.0(@0no-co/graphqlsp@file:packages/graphqlsp(graphql@16.8.1)(typescript@5.3.3))(graphql@16.8.1)(typescript@5.3.3)':
     dependencies:
       '@0no-co/graphqlsp': file:packages/graphqlsp(graphql@16.8.1)(typescript@5.3.3)
-      '@gql.tada/internal': 1.1.0(graphql@16.8.1)(typescript@5.3.3)
+      '@gql.tada/internal': 1.2.0(graphql@16.8.1)(typescript@5.3.3)
       graphql: 16.8.1
       typescript: 5.3.3
 
-  '@gql.tada/internal@1.1.0(graphql@16.8.1)(typescript@5.3.3)':
+  '@gql.tada/internal@1.2.0(graphql@16.8.1)(typescript@5.3.3)':
     dependencies:
       '@0no-co/graphql.web': 1.3.2(graphql@16.8.1)
       graphql: 16.8.1
@@ -3629,7 +3635,7 @@ snapshots:
       graphql: 16.8.1
       tslib: 2.6.3
 
-  '@graphql-codegen/cli@5.0.0(@types/node@18.15.11)(enquirer@2.4.1)(graphql@16.8.1)(typescript@5.3.3)':
+  '@graphql-codegen/cli@5.0.0(@types/node@18.19.130)(enquirer@2.4.1)(graphql@16.8.1)(typescript@5.3.3)':
     dependencies:
       '@babel/generator': 7.28.5
       '@babel/template': 7.27.2
@@ -3639,12 +3645,12 @@ snapshots:
       '@graphql-tools/apollo-engine-loader': 8.0.24(graphql@16.8.1)
       '@graphql-tools/code-file-loader': 8.1.24(graphql@16.8.1)
       '@graphql-tools/git-loader': 8.0.28(graphql@16.8.1)
-      '@graphql-tools/github-loader': 8.0.22(@types/node@18.15.11)(graphql@16.8.1)
+      '@graphql-tools/github-loader': 8.0.22(@types/node@18.19.130)(graphql@16.8.1)
       '@graphql-tools/graphql-file-loader': 8.1.4(graphql@16.8.1)
       '@graphql-tools/json-file-loader': 8.0.22(graphql@16.8.1)
       '@graphql-tools/load': 8.1.4(graphql@16.8.1)
-      '@graphql-tools/prisma-loader': 8.0.17(@types/node@18.15.11)(graphql@16.8.1)
-      '@graphql-tools/url-loader': 8.0.33(@types/node@18.15.11)(graphql@16.8.1)
+      '@graphql-tools/prisma-loader': 8.0.17(@types/node@18.19.130)(graphql@16.8.1)
+      '@graphql-tools/url-loader': 8.0.33(@types/node@18.19.130)(graphql@16.8.1)
       '@graphql-tools/utils': 10.10.1(graphql@16.8.1)
       '@whatwg-node/fetch': 0.8.8
       chalk: 4.1.2
@@ -3652,8 +3658,8 @@ snapshots:
       debounce: 1.2.1
       detect-indent: 6.1.0
       graphql: 16.8.1
-      graphql-config: 5.1.5(@types/node@18.15.11)(graphql@16.8.1)(typescript@5.3.3)
-      inquirer: 8.2.7(@types/node@18.15.11)
+      graphql-config: 5.1.5(@types/node@18.19.130)(graphql@16.8.1)(typescript@5.3.3)
+      inquirer: 8.2.7(@types/node@18.19.130)
       is-glob: 4.0.3
       jiti: 1.21.7
       json-to-pretty-yaml: 1.2.2
@@ -3893,7 +3899,7 @@ snapshots:
       - uWebSockets.js
       - utf-8-validate
 
-  '@graphql-tools/executor-http@1.3.3(@types/node@18.15.11)(graphql@16.8.1)':
+  '@graphql-tools/executor-http@1.3.3(@types/node@18.19.130)(graphql@16.8.1)':
     dependencies:
       '@graphql-hive/signal': 1.0.0
       '@graphql-tools/executor-common': 0.0.4(graphql@16.8.1)
@@ -3903,7 +3909,7 @@ snapshots:
       '@whatwg-node/fetch': 0.10.13
       '@whatwg-node/promise-helpers': 1.3.2
       graphql: 16.8.1
-      meros: 1.3.2(@types/node@18.15.11)
+      meros: 1.3.2(@types/node@18.19.130)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@types/node'
@@ -3942,9 +3948,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@graphql-tools/github-loader@8.0.22(@types/node@18.15.11)(graphql@16.8.1)':
+  '@graphql-tools/github-loader@8.0.22(@types/node@18.19.130)(graphql@16.8.1)':
     dependencies:
-      '@graphql-tools/executor-http': 1.3.3(@types/node@18.15.11)(graphql@16.8.1)
+      '@graphql-tools/executor-http': 1.3.3(@types/node@18.19.130)(graphql@16.8.1)
       '@graphql-tools/graphql-tag-pluck': 8.3.23(graphql@16.8.1)
       '@graphql-tools/utils': 10.10.1(graphql@16.8.1)
       '@whatwg-node/fetch': 0.10.13
@@ -4017,9 +4023,9 @@ snapshots:
       graphql: 16.8.1
       tslib: 2.6.3
 
-  '@graphql-tools/prisma-loader@8.0.17(@types/node@18.15.11)(graphql@16.8.1)':
+  '@graphql-tools/prisma-loader@8.0.17(@types/node@18.19.130)(graphql@16.8.1)':
     dependencies:
-      '@graphql-tools/url-loader': 8.0.33(@types/node@18.15.11)(graphql@16.8.1)
+      '@graphql-tools/url-loader': 8.0.33(@types/node@18.19.130)(graphql@16.8.1)
       '@graphql-tools/utils': 10.10.1(graphql@16.8.1)
       '@types/js-yaml': 4.0.9
       '@whatwg-node/fetch': 0.10.13
@@ -4062,10 +4068,10 @@ snapshots:
       graphql: 16.8.1
       tslib: 2.8.1
 
-  '@graphql-tools/url-loader@8.0.33(@types/node@18.15.11)(graphql@16.8.1)':
+  '@graphql-tools/url-loader@8.0.33(@types/node@18.19.130)(graphql@16.8.1)':
     dependencies:
       '@graphql-tools/executor-graphql-ws': 2.0.7(graphql@16.8.1)
-      '@graphql-tools/executor-http': 1.3.3(@types/node@18.15.11)(graphql@16.8.1)
+      '@graphql-tools/executor-http': 1.3.3(@types/node@18.19.130)(graphql@16.8.1)
       '@graphql-tools/executor-legacy-ws': 1.1.21(graphql@16.8.1)
       '@graphql-tools/utils': 10.10.1(graphql@16.8.1)
       '@graphql-tools/wrap': 10.1.4(graphql@16.8.1)
@@ -4112,6 +4118,13 @@ snapshots:
       iconv-lite: 0.7.0
     optionalDependencies:
       '@types/node': 18.15.11
+
+  '@inquirer/external-editor@1.0.3(@types/node@18.19.130)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.0
+    optionalDependencies:
+      '@types/node': 18.19.130
 
   '@jest/schemas@29.6.3':
     dependencies:
@@ -4457,6 +4470,10 @@ snapshots:
   '@types/node@12.20.55': {}
 
   '@types/node@18.15.11': {}
+
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
 
   '@types/prop-types@15.7.15': {}
 
@@ -5056,12 +5073,12 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
-  gql.tada@1.10.0(graphql@16.8.1)(typescript@5.3.3):
+  gql.tada@1.11.0(graphql@16.8.1)(typescript@5.3.3):
     dependencies:
       '@0no-co/graphql.web': 1.3.2(graphql@16.8.1)
-      '@0no-co/graphqlsp': 1.16.0(graphql@16.8.1)(typescript@5.3.3)
-      '@gql.tada/cli-utils': 1.8.0(@0no-co/graphqlsp@file:packages/graphqlsp(graphql@16.8.1)(typescript@5.3.3))(graphql@16.8.1)(typescript@5.3.3)
-      '@gql.tada/internal': 1.1.0(graphql@16.8.1)(typescript@5.3.3)
+      '@0no-co/graphqlsp': 1.17.1(graphql@16.8.1)(typescript@5.3.3)
+      '@gql.tada/cli-utils': 1.9.0(@0no-co/graphqlsp@file:packages/graphqlsp(graphql@16.8.1)(typescript@5.3.3))(graphql@16.8.1)(typescript@5.3.3)
+      '@gql.tada/internal': 1.2.0(graphql@16.8.1)(typescript@5.3.3)
       typescript: 5.3.3
     transitivePeerDependencies:
       - '@gql.tada/svelte-support'
@@ -5070,13 +5087,13 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  graphql-config@5.1.5(@types/node@18.15.11)(graphql@16.8.1)(typescript@5.3.3):
+  graphql-config@5.1.5(@types/node@18.19.130)(graphql@16.8.1)(typescript@5.3.3):
     dependencies:
       '@graphql-tools/graphql-file-loader': 8.1.4(graphql@16.8.1)
       '@graphql-tools/json-file-loader': 8.0.22(graphql@16.8.1)
       '@graphql-tools/load': 8.1.4(graphql@16.8.1)
       '@graphql-tools/merge': 9.1.3(graphql@16.8.1)
-      '@graphql-tools/url-loader': 8.0.33(@types/node@18.15.11)(graphql@16.8.1)
+      '@graphql-tools/url-loader': 8.0.33(@types/node@18.19.130)(graphql@16.8.1)
       '@graphql-tools/utils': 10.10.1(graphql@16.8.1)
       cosmiconfig: 8.3.6(typescript@5.3.3)
       graphql: 16.8.1
@@ -5178,9 +5195,9 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  inquirer@8.2.7(@types/node@18.15.11):
+  inquirer@8.2.7(@types/node@18.19.130):
     dependencies:
-      '@inquirer/external-editor': 1.0.3(@types/node@18.15.11)
+      '@inquirer/external-editor': 1.0.3(@types/node@18.19.130)
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       cli-cursor: 3.1.0
@@ -5410,9 +5427,9 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  meros@1.3.2(@types/node@18.15.11):
+  meros@1.3.2(@types/node@18.19.130):
     optionalDependencies:
-      '@types/node': 18.15.11
+      '@types/node': 18.19.130
 
   micromatch@4.0.5:
     dependencies:
@@ -5949,14 +5966,14 @@ snapshots:
 
   ts-log@2.2.7: {}
 
-  ts-node@10.9.1(@types/node@18.15.11)(typescript@5.3.3):
+  ts-node@10.9.1(@types/node@18.19.130)(typescript@5.3.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 18.15.11
+      '@types/node': 18.19.130
       acorn: 8.15.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -5988,6 +6005,8 @@ snapshots:
   ufo@1.6.1: {}
 
   unc-path-regex@0.1.2: {}
+
+  undici-types@5.26.5: {}
 
   undici@5.29.0:
     dependencies:

--- a/test/e2e/fixture-project-tada-multi-schema/package.json
+++ b/test/e2e/fixture-project-tada-multi-schema/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "graphql": "^16.0.0",
-    "gql.tada": "1.10.0",
+    "gql.tada": "^1.11.0",
     "@graphql-typed-document-node/core": "^3.0.0",
     "@0no-co/graphqlsp": "workspace:*",
     "@urql/core": "^4.0.4"

--- a/test/e2e/fixture-project-tada/package.json
+++ b/test/e2e/fixture-project-tada/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "graphql": "^16.0.0",
-    "gql.tada": "^1.10.0",
+    "gql.tada": "^1.11.0",
     "@graphql-typed-document-node/core": "^3.0.0",
     "@0no-co/graphqlsp": "workspace:*",
     "@urql/core": "^4.0.4"


### PR DESCRIPTION
## Summary

See https://github.com/0no-co/gql.tada/pull/556

This now preserves output file header comments, such as for ignoring other linters than eslint/prettier. This needs to be bumped here too to be consistent.

## Set of changes

- Bump `gql.tada` and `@gql.tada/internal`
- Hook up new introspection preamble APIs
- Drive-by fix type errors