### PR TITLE
Add gql.tada go-to-definition support

### DIFF
--- a/.changeset/tidy-definition-wolves.md
+++ b/.changeset/tidy-definition-wolves.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphqlsp': patch
+---
+
+Add go-to-definition support for gql.tada result fields and GraphQL document fields.

--- a/packages/graphqlsp/src/autoComplete.ts
+++ b/packages/graphqlsp/src/autoComplete.ts
@@ -27,7 +27,7 @@ import { Cursor } from './ast/cursor';
 import { resolveTemplate } from './ast/resolve';
 import { getToken } from './ast/token';
 import { getSuggestionsForFragmentSpread } from './graphql/getFragmentSpreadSuggestions';
-import { SchemaRef } from './graphql/getSchema';
+import { SchemaRef, getSchemaForName } from './graphql/getSchema';
 
 export function getGraphQLCompletions(
   filename: string,
@@ -51,10 +51,7 @@ export function getGraphQLCompletions(
   if (isCallExpression && checks.isGraphQLCall(node, typeChecker)) {
     const schemaName = checks.getSchemaName(node, typeChecker);
 
-    schemaToUse =
-      schemaName && schema.multi[schemaName]
-        ? schema.multi[schemaName]?.schema
-        : schema.current?.schema;
+    schemaToUse = getSchemaForName(schema, schemaName);
 
     const foundToken = getToken(node.arguments[0], cursorPosition);
     if (

--- a/packages/graphqlsp/src/definition.ts
+++ b/packages/graphqlsp/src/definition.ts
@@ -24,7 +24,7 @@ import {
   getSource,
 } from './ast';
 import * as checks from './ast/checks';
-import { SchemaRef } from './graphql/getSchema';
+import { SchemaRef, getSchemaForName } from './graphql/getSchema';
 
 interface GraphQLFieldLocation {
   fileName: string;
@@ -41,11 +41,6 @@ interface TadaCacheMatch {
 
 const isPositionInRange = (position: number, start: number, end: number) =>
   position >= start && position < end;
-
-const getSchemaResult = (schema: SchemaRef, schemaName: string | null) =>
-  schemaName && schema.multi[schemaName]
-    ? schema.multi[schemaName]
-    : schema.current;
 
 const makeDefinitionInfo = (
   location: GraphQLFieldLocation
@@ -354,7 +349,7 @@ const getDefinitionForDocumentField = (
 
   if (isCallExpression && checks.isGraphQLCall(node, typeChecker)) {
     schemaName = checks.getSchemaName(node, typeChecker);
-    schemaToUse = getSchemaResult(schema, schemaName)?.schema;
+    schemaToUse = getSchemaForName(schema, schemaName);
     documentNode = node.arguments[0] as ts.StringLiteralLike;
   } else if (!isCallExpression && checks.isGraphQLTag(node)) {
     if (!ts.isNoSubstitutionTemplateLiteral(node.template)) return undefined;

--- a/packages/graphqlsp/src/definition.ts
+++ b/packages/graphqlsp/src/definition.ts
@@ -1,0 +1,496 @@
+import path from 'path';
+
+import {
+  FieldNode,
+  FragmentDefinitionNode,
+  GraphQLNamedType,
+  GraphQLSchema,
+  Kind,
+  SelectionSetNode,
+  TypeInfo,
+  isInterfaceType,
+  isObjectType,
+  parse,
+  visit,
+  visitWithTypeInfo,
+} from 'graphql';
+
+import { ts } from './ts';
+import {
+  bubbleUpCallExpression,
+  bubbleUpTemplate,
+  findAllCallExpressions,
+  findNode,
+  getSource,
+} from './ast';
+import * as checks from './ast/checks';
+import { SchemaRef } from './graphql/getSchema';
+
+interface GraphQLFieldLocation {
+  fileName: string;
+  fieldName: string;
+  parentName: string;
+  start: number;
+  length: number;
+}
+
+interface TadaCacheMatch {
+  documentText: string;
+  responsePath: string[];
+}
+
+const isPositionInRange = (position: number, start: number, end: number) =>
+  position >= start && position < end;
+
+const getSchemaResult = (schema: SchemaRef, schemaName: string | null) =>
+  schemaName && schema.multi[schemaName]
+    ? schema.multi[schemaName]
+    : schema.current;
+
+const makeDefinitionInfo = (
+  location: GraphQLFieldLocation
+): ts.DefinitionInfo => ({
+  fileName: location.fileName,
+  textSpan: {
+    start: location.start,
+    length: location.length,
+  },
+  kind: ts.ScriptElementKind.memberVariableElement,
+  name: location.fieldName,
+  containerKind: ts.ScriptElementKind.interfaceElement,
+  containerName: location.parentName,
+});
+
+const getNameText = (name: ts.PropertyName): string | undefined => {
+  if (ts.isIdentifier(name) || ts.isStringLiteralLike(name)) return name.text;
+  if (ts.isNumericLiteral(name)) return name.text;
+  return undefined;
+};
+
+const containsNode = (outer: ts.Node, inner: ts.Node): boolean =>
+  inner.getStart() >= outer.getStart() && inner.getEnd() <= outer.getEnd();
+
+const getTypeReferenceName = (node: ts.TypeReferenceNode): string => {
+  const name = node.typeName;
+  return ts.isIdentifier(name) ? name.text : name.right.text;
+};
+
+const getTadaCacheMatch = (node: ts.Node): TadaCacheMatch | undefined => {
+  const responsePath: string[] = [];
+  let current: ts.Node | undefined = node;
+  let cacheProperty: ts.PropertySignature | undefined;
+
+  while (current) {
+    if (ts.isPropertySignature(current)) {
+      if (
+        current.parent &&
+        ts.isInterfaceDeclaration(current.parent) &&
+        current.parent.name.text === 'setupCache' &&
+        ts.isStringLiteralLike(current.name)
+      ) {
+        cacheProperty = current;
+        break;
+      }
+
+      const name = getNameText(current.name);
+      if (!name) return undefined;
+      responsePath.push(name);
+    }
+    current = current.parent;
+  }
+
+  if (!cacheProperty || !ts.isStringLiteralLike(cacheProperty.name)) {
+    return undefined;
+  }
+
+  const cacheType = cacheProperty.type;
+  if (!cacheType || !ts.isTypeReferenceNode(cacheType)) return undefined;
+  if (getTypeReferenceName(cacheType) !== 'TadaDocumentNode') return undefined;
+
+  const resultType = cacheType.typeArguments?.[0];
+  if (!resultType || !containsNode(resultType, node)) return undefined;
+
+  responsePath.reverse();
+  if (!responsePath.length) return undefined;
+
+  return {
+    documentText: cacheProperty.name.text,
+    responsePath,
+  };
+};
+
+const findTadaCacheMatch = (
+  definition: ts.DefinitionInfo,
+  info: ts.server.PluginCreateInfo
+): TadaCacheMatch | undefined => {
+  const program = info.languageService.getProgram();
+  const source = program?.getSourceFile(definition.fileName);
+  if (!source) return undefined;
+
+  const node = findNode(source, definition.textSpan.start);
+  return node && getTadaCacheMatch(node);
+};
+
+const findDocumentCall = (
+  documentText: string,
+  schemaName: string | null,
+  info: ts.server.PluginCreateInfo
+): { fileName: string; node: ts.StringLiteralLike } | undefined => {
+  const program = info.languageService.getProgram();
+  if (!program) return undefined;
+
+  for (const source of program.getSourceFiles()) {
+    if (source.isDeclarationFile) continue;
+    if (!source.getText().includes(documentText)) continue;
+
+    const { nodes } = findAllCallExpressions(source, info, {
+      searchExternal: false,
+      collectFragments: false,
+    });
+
+    for (const found of nodes) {
+      if (found.node.text !== documentText) continue;
+      if (schemaName && found.schema !== schemaName) continue;
+      return { fileName: source.fileName, node: found.node };
+    }
+  }
+};
+
+const getSchemaNameForTurboFile = (
+  fileName: string,
+  schema: SchemaRef
+): string | null => {
+  const normalize = (input: string) => path.normalize(input).toLowerCase();
+  const target = normalize(fileName);
+  for (const [schemaName, turboFile] of schema.turboLocations) {
+    if (normalize(turboFile) === target) return schemaName;
+  }
+  return null;
+};
+
+const findFieldByResponsePath = (
+  documentText: string,
+  responsePath: readonly string[]
+): FieldNode | undefined => {
+  let document;
+  try {
+    document = parse(documentText);
+  } catch (_error) {
+    return undefined;
+  }
+
+  const fragments = new Map<string, FragmentDefinitionNode>();
+  for (const definition of document.definitions) {
+    if (definition.kind === Kind.FRAGMENT_DEFINITION) {
+      fragments.set(definition.name.value, definition);
+    }
+  }
+
+  const findInSelectionSet = (
+    selectionSet: SelectionSetNode,
+    path: readonly string[],
+    seenFragments = new Set<string>()
+  ): FieldNode | undefined => {
+    const [head, ...rest] = path;
+    if (!head) return undefined;
+
+    for (const selection of selectionSet.selections) {
+      if (selection.kind === Kind.FIELD) {
+        const responseName = selection.alias
+          ? selection.alias.value
+          : selection.name.value;
+        if (responseName !== head) continue;
+        if (!rest.length) return selection;
+        if (!selection.selectionSet) return undefined;
+        const found = findInSelectionSet(
+          selection.selectionSet,
+          rest,
+          seenFragments
+        );
+        if (found) return found;
+      } else if (selection.kind === Kind.INLINE_FRAGMENT) {
+        const found = findInSelectionSet(
+          selection.selectionSet,
+          path,
+          seenFragments
+        );
+        if (found) return found;
+      } else if (selection.kind === Kind.FRAGMENT_SPREAD) {
+        const name = selection.name.value;
+        if (seenFragments.has(name)) continue;
+        const fragment = fragments.get(name);
+        if (!fragment) continue;
+        seenFragments.add(name);
+        const found = findInSelectionSet(
+          fragment.selectionSet,
+          path,
+          seenFragments
+        );
+        if (found) return found;
+      }
+    }
+  };
+
+  for (const definition of document.definitions) {
+    if (
+      definition.kind === Kind.OPERATION_DEFINITION ||
+      definition.kind === Kind.FRAGMENT_DEFINITION
+    ) {
+      const found = findInSelectionSet(definition.selectionSet, responsePath);
+      if (found) return found;
+    }
+  }
+};
+
+const getFieldAtOffset = (
+  schema: GraphQLSchema,
+  documentText: string,
+  offset: number
+):
+  | {
+      field: FieldNode;
+      parentType: GraphQLNamedType;
+      boundStart: number;
+      boundLength: number;
+    }
+  | undefined => {
+  let document;
+  try {
+    document = parse(documentText);
+  } catch (_error) {
+    return undefined;
+  }
+
+  let found:
+    | {
+        field: FieldNode;
+        parentType: GraphQLNamedType;
+        boundStart: number;
+        boundLength: number;
+      }
+    | undefined;
+
+  const typeInfo = new TypeInfo(schema);
+  visit(
+    document,
+    visitWithTypeInfo(typeInfo, {
+      Field: {
+        enter(field) {
+          const nameLoc = field.name.loc;
+          const aliasLoc = field.alias?.loc;
+          const loc =
+            nameLoc && isPositionInRange(offset, nameLoc.start, nameLoc.end)
+              ? nameLoc
+              : aliasLoc &&
+                isPositionInRange(offset, aliasLoc.start, aliasLoc.end)
+              ? aliasLoc
+              : null;
+          if (!loc) return;
+
+          const parentType = typeInfo.getParentType();
+          if (!parentType) return;
+
+          found = {
+            field,
+            parentType,
+            boundStart: loc.start,
+            boundLength: loc.end - loc.start,
+          };
+          return false;
+        },
+      },
+    })
+  );
+
+  return found;
+};
+
+const getSchemaFieldLocation = (
+  schema: SchemaRef,
+  schemaName: string | null,
+  parentType: GraphQLNamedType,
+  fieldName: string
+): GraphQLFieldLocation | undefined => {
+  const schemaSource = schema.sourceLocations.get(schemaName);
+  if (!schemaSource) return undefined;
+
+  if (!isObjectType(parentType) && !isInterfaceType(parentType)) {
+    return undefined;
+  }
+
+  const field = parentType.getFields()[fieldName];
+  const loc = field?.astNode?.name.loc;
+  if (!field || !loc) return undefined;
+
+  return {
+    fileName: schemaSource,
+    fieldName,
+    parentName: parentType.name,
+    start: loc.start,
+    length: loc.end - loc.start,
+  };
+};
+
+const getDefinitionForDocumentField = (
+  filename: string,
+  cursorPosition: number,
+  schema: SchemaRef,
+  info: ts.server.PluginCreateInfo
+): ts.DefinitionInfoAndBoundSpan | undefined => {
+  const isCallExpression = info.config.templateIsCallExpression ?? true;
+  const typeChecker = info.languageService.getProgram()?.getTypeChecker();
+  const source = getSource(info, filename);
+  if (!source) return undefined;
+
+  let node = findNode(source, cursorPosition);
+  if (!node) return undefined;
+  node = isCallExpression
+    ? bubbleUpCallExpression(node)
+    : bubbleUpTemplate(node);
+
+  let documentNode: ts.StringLiteralLike;
+  let schemaName: string | null = null;
+  let schemaToUse: GraphQLSchema | undefined;
+
+  if (isCallExpression && checks.isGraphQLCall(node, typeChecker)) {
+    schemaName = checks.getSchemaName(node, typeChecker);
+    schemaToUse = getSchemaResult(schema, schemaName)?.schema;
+    documentNode = node.arguments[0] as ts.StringLiteralLike;
+  } else if (!isCallExpression && checks.isGraphQLTag(node)) {
+    if (!ts.isNoSubstitutionTemplateLiteral(node.template)) return undefined;
+    schemaToUse = schema.current?.schema;
+    documentNode = node.template;
+  } else {
+    return undefined;
+  }
+
+  if (!schemaToUse || !ts.isStringLiteralLike(documentNode)) return undefined;
+
+  const documentStart = documentNode.getStart() + 1;
+  const documentOffset = cursorPosition - documentStart;
+  if (documentOffset < 0 || documentOffset >= documentNode.text.length) {
+    return undefined;
+  }
+
+  const found = getFieldAtOffset(
+    schemaToUse,
+    documentNode.text,
+    documentOffset
+  );
+  if (!found) return undefined;
+
+  const location = getSchemaFieldLocation(
+    schema,
+    schemaName,
+    found.parentType,
+    found.field.name.value
+  );
+  if (!location) return undefined;
+
+  return {
+    textSpan: {
+      start: documentStart + found.boundStart,
+      length: found.boundLength,
+    },
+    definitions: [makeDefinitionInfo(location)],
+  };
+};
+
+const getDefinitionForTadaResultField = (
+  schema: SchemaRef,
+  info: ts.server.PluginCreateInfo,
+  originalDefinitions: readonly ts.DefinitionInfo[] | undefined
+): readonly ts.DefinitionInfo[] | undefined => {
+  if (!originalDefinitions?.length) return undefined;
+
+  let sawTadaCacheDefinition = false;
+  for (const definition of originalDefinitions) {
+    const cacheMatch = findTadaCacheMatch(definition, info);
+    if (!cacheMatch) continue;
+    sawTadaCacheDefinition = true;
+
+    const schemaName = getSchemaNameForTurboFile(definition.fileName, schema);
+    const documentCall = findDocumentCall(
+      cacheMatch.documentText,
+      schemaName,
+      info
+    );
+    if (!documentCall) continue;
+
+    const field = findFieldByResponsePath(
+      cacheMatch.documentText,
+      cacheMatch.responsePath
+    );
+    const loc = (field?.alias || field?.name)?.loc;
+    if (!loc) continue;
+
+    return [
+      {
+        fileName: documentCall.fileName,
+        textSpan: {
+          start: documentCall.node.getStart() + 1 + loc.start,
+          length: loc.end - loc.start,
+        },
+        kind: ts.ScriptElementKind.memberVariableElement,
+        name: cacheMatch.responsePath[cacheMatch.responsePath.length - 1]!,
+        containerKind: ts.ScriptElementKind.scriptElement,
+        containerName: '',
+      },
+    ];
+  }
+
+  // If TypeScript was about to navigate into gql.tada's turbo cache, don't
+  // fall back to that generated file. We either remap to the user's GraphQL
+  // document above, or suppress the generated-cache location.
+  return sawTadaCacheDefinition ? [] : undefined;
+};
+
+export function getGraphQLDefinitionAtPosition(
+  filename: string,
+  cursorPosition: number,
+  schema: SchemaRef,
+  info: ts.server.PluginCreateInfo,
+  originalDefinitions: readonly ts.DefinitionInfo[] | undefined
+): readonly ts.DefinitionInfo[] | undefined {
+  const documentFieldDefinition = getDefinitionForDocumentField(
+    filename,
+    cursorPosition,
+    schema,
+    info
+  );
+  if (documentFieldDefinition?.definitions?.length) {
+    return documentFieldDefinition.definitions;
+  }
+
+  return getDefinitionForTadaResultField(schema, info, originalDefinitions);
+}
+
+export function getGraphQLDefinitionAndBoundSpan(
+  filename: string,
+  cursorPosition: number,
+  schema: SchemaRef,
+  info: ts.server.PluginCreateInfo,
+  original: ts.DefinitionInfoAndBoundSpan | undefined
+): ts.DefinitionInfoAndBoundSpan | undefined {
+  const documentFieldDefinition = getDefinitionForDocumentField(
+    filename,
+    cursorPosition,
+    schema,
+    info
+  );
+  if (documentFieldDefinition?.definitions?.length) {
+    return documentFieldDefinition;
+  }
+
+  const definitions = getDefinitionForTadaResultField(
+    schema,
+    info,
+    original?.definitions
+  );
+  if (!definitions) return undefined;
+
+  return {
+    textSpan: original?.textSpan || { start: cursorPosition, length: 1 },
+    definitions,
+  };
+}

--- a/packages/graphqlsp/src/definition.ts
+++ b/packages/graphqlsp/src/definition.ts
@@ -116,38 +116,65 @@ const getTadaCacheMatch = (node: ts.Node): TadaCacheMatch | undefined => {
 
 const findTadaCacheMatch = (
   definition: ts.DefinitionInfo,
-  info: ts.server.PluginCreateInfo
+  program: ts.Program
 ): TadaCacheMatch | undefined => {
-  const program = info.languageService.getProgram();
-  const source = program?.getSourceFile(definition.fileName);
+  const source = program.getSourceFile(definition.fileName);
   if (!source) return undefined;
 
   const node = findNode(source, definition.textSpan.start);
   return node && getTadaCacheMatch(node);
 };
 
-const findDocumentCall = (
+const findDocumentCallInSource = (
+  source: ts.SourceFile,
   documentText: string,
   schemaName: string | null,
   info: ts.server.PluginCreateInfo
 ): { fileName: string; node: ts.StringLiteralLike } | undefined => {
-  const program = info.languageService.getProgram();
-  if (!program) return undefined;
+  if (source.isDeclarationFile) return undefined;
+  if (!source.getText().includes(documentText)) return undefined;
+
+  const { nodes } = findAllCallExpressions(source, info, {
+    searchExternal: false,
+    collectFragments: false,
+  });
+
+  for (const found of nodes) {
+    if (found.node.text !== documentText) continue;
+    if (schemaName && found.schema !== schemaName) continue;
+    return { fileName: source.fileName, node: found.node };
+  }
+};
+
+const findDocumentCall = (
+  documentText: string,
+  schemaName: string | null,
+  preferFileName: string,
+  program: ts.Program,
+  info: ts.server.PluginCreateInfo
+): { fileName: string; node: ts.StringLiteralLike } | undefined => {
+  // The document literal is usually co-located with the result usage, so the
+  // originating file is the likeliest match.
+  const preferred = program.getSourceFile(preferFileName);
+  if (preferred) {
+    const match = findDocumentCallInSource(
+      preferred,
+      documentText,
+      schemaName,
+      info
+    );
+    if (match) return match;
+  }
 
   for (const source of program.getSourceFiles()) {
-    if (source.isDeclarationFile) continue;
-    if (!source.getText().includes(documentText)) continue;
-
-    const { nodes } = findAllCallExpressions(source, info, {
-      searchExternal: false,
-      collectFragments: false,
-    });
-
-    for (const found of nodes) {
-      if (found.node.text !== documentText) continue;
-      if (schemaName && found.schema !== schemaName) continue;
-      return { fileName: source.fileName, node: found.node };
-    }
+    if (source === preferred) continue;
+    const match = findDocumentCallInSource(
+      source,
+      documentText,
+      schemaName,
+      info
+    );
+    if (match) return match;
   }
 };
 
@@ -181,6 +208,8 @@ const findFieldByResponsePath = (
     }
   }
 
+  // Cyclic fragment spreads can only loop at a fixed response-path position.
+  // Advancing into a field shrinks the path, so the cycle guard resets there.
   const findInSelectionSet = (
     selectionSet: SelectionSetNode,
     path: readonly string[],
@@ -197,11 +226,7 @@ const findFieldByResponsePath = (
         if (responseName !== head) continue;
         if (!rest.length) return selection;
         if (!selection.selectionSet) return undefined;
-        const found = findInSelectionSet(
-          selection.selectionSet,
-          rest,
-          seenFragments
-        );
+        const found = findInSelectionSet(selection.selectionSet, rest);
         if (found) return found;
       } else if (selection.kind === Kind.INLINE_FRAGMENT) {
         const found = findInSelectionSet(
@@ -392,15 +417,19 @@ const getDefinitionForDocumentField = (
 };
 
 const getDefinitionForTadaResultField = (
+  filename: string,
   schema: SchemaRef,
   info: ts.server.PluginCreateInfo,
   originalDefinitions: readonly ts.DefinitionInfo[] | undefined
 ): readonly ts.DefinitionInfo[] | undefined => {
   if (!originalDefinitions?.length) return undefined;
 
+  const program = info.languageService.getProgram();
+  if (!program) return undefined;
+
   let sawTadaCacheDefinition = false;
   for (const definition of originalDefinitions) {
-    const cacheMatch = findTadaCacheMatch(definition, info);
+    const cacheMatch = findTadaCacheMatch(definition, program);
     if (!cacheMatch) continue;
     sawTadaCacheDefinition = true;
 
@@ -408,6 +437,8 @@ const getDefinitionForTadaResultField = (
     const documentCall = findDocumentCall(
       cacheMatch.documentText,
       schemaName,
+      filename,
+      program,
       info
     );
     if (!documentCall) continue;
@@ -434,9 +465,8 @@ const getDefinitionForTadaResultField = (
     ];
   }
 
-  // If TypeScript was about to navigate into gql.tada's turbo cache, don't
-  // fall back to that generated file. We either remap to the user's GraphQL
-  // document above, or suppress the generated-cache location.
+  // `[]` suppresses navigation into gql.tada's generated turbo cache;
+  // `undefined` lets the original definitions stand.
   return sawTadaCacheDefinition ? [] : undefined;
 };
 
@@ -457,7 +487,12 @@ export function getGraphQLDefinitionAtPosition(
     return documentFieldDefinition.definitions;
   }
 
-  return getDefinitionForTadaResultField(schema, info, originalDefinitions);
+  return getDefinitionForTadaResultField(
+    filename,
+    schema,
+    info,
+    originalDefinitions
+  );
 }
 
 export function getGraphQLDefinitionAndBoundSpan(
@@ -478,6 +513,7 @@ export function getGraphQLDefinitionAndBoundSpan(
   }
 
   const definitions = getDefinitionForTadaResultField(
+    filename,
     schema,
     info,
     original?.definitions

--- a/packages/graphqlsp/src/graphql/getSchema.ts
+++ b/packages/graphqlsp/src/graphql/getSchema.ts
@@ -2,7 +2,7 @@ import type { Stats, PathLike } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'path';
 
-import type { IntrospectionQuery } from 'graphql';
+import type { GraphQLSchema, IntrospectionQuery } from 'graphql';
 
 import {
   type GraphQLSPConfig,
@@ -145,6 +145,15 @@ export interface SchemaRef {
    * missed; throttled internally, so it's safe to call often. */
   checkStale(): void;
 }
+
+/** Falls back to the `current` schema for single-schema setups or unnamed documents. */
+export const getSchemaForName = (
+  schema: SchemaRef,
+  schemaName: string | null
+): GraphQLSchema | undefined =>
+  schemaName && schema.multi[schemaName]
+    ? schema.multi[schemaName]?.schema
+    : schema.current?.schema;
 
 // `onError` on autoupdate and `reload` on load ship with newer
 // @gql.tada/internal versions; older versions simply ignore both

--- a/packages/graphqlsp/src/graphql/getSchema.ts
+++ b/packages/graphqlsp/src/graphql/getSchema.ts
@@ -137,6 +137,10 @@ export interface SchemaRef {
   readonly errors: SchemaErrors;
   /** Typings output paths successfully written this session, mapped to their last write time. */
   readonly outputLocations: ReadonlyMap<string, number>;
+  /** File-based schema origins, keyed by schema name (`null` for single-schema setups). */
+  readonly sourceLocations: ReadonlyMap<string | null, string>;
+  /** gql.tada turbo cache files, keyed by schema name (`null` for single-schema setups). */
+  readonly turboLocations: ReadonlyMap<string | null, string>;
   /** Best-effort detection of schema file changes that the file watcher
    * missed; throttled internally, so it's safe to call often. */
   checkStale(): void;
@@ -171,6 +175,8 @@ export const loadSchema = (
     write: new Map(),
   };
   const outputLocations = new Map<string, number>();
+  const sourceLocations = new Map<string | null, string>();
+  const turboLocations = new Map<string | null, string>();
 
   let inner: InternalSchemaRef<SchemaLoaderResult | null> | null = null;
   let detectStaleSchemas: (() => void) | null = null;
@@ -179,6 +185,8 @@ export const loadSchema = (
   const ref: SchemaRef = {
     errors,
     outputLocations,
+    sourceLocations,
+    turboLocations,
     get current() {
       return inner && inner.current;
     },
@@ -220,6 +228,29 @@ export const loadSchema = (
       info.config.tadaDisablePreprocessing ?? false;
 
     logger('Resolving schema from "schema" config: ' + JSON.stringify(config));
+
+    sourceLocations.clear();
+    turboLocations.clear();
+    const rememberLocations = (
+      name: string | null,
+      input: SingleSchemaInput
+    ) => {
+      if (typeof input.schema === 'string' && !getURLConfig(input.schema)) {
+        sourceLocations.set(name, path.resolve(rootPath, input.schema));
+      }
+      if (input.tadaTurboLocation) {
+        turboLocations.set(
+          name,
+          path.resolve(rootPath, input.tadaTurboLocation)
+        );
+      }
+    };
+    if ('schemas' in config) {
+      for (const input of config.schemas) rememberLocations(input.name, input);
+    } else {
+      rememberLocations(null, config);
+    }
+
     inner = loadRef(config);
 
     const setLoadError = (name: string | null | undefined, error: unknown) => {

--- a/packages/graphqlsp/src/index.ts
+++ b/packages/graphqlsp/src/index.ts
@@ -4,6 +4,10 @@ import { ts, init as initTypeScript } from './ts';
 import { loadSchema } from './graphql/getSchema';
 import { getGraphQLCompletions } from './autoComplete';
 import { getGraphQLQuickInfo } from './quickInfo';
+import {
+  getGraphQLDefinitionAndBoundSpan,
+  getGraphQLDefinitionAtPosition,
+} from './definition';
 import { ALL_DIAGNOSTICS, getGraphQLDiagnostics } from './diagnostics';
 import { templates } from './ast/templates';
 import { getPersistedCodeFixAtPosition } from './persisted';
@@ -199,6 +203,50 @@ function create(info: ts.server.PluginCreateInfo) {
     } else {
       return original;
     }
+  };
+
+  proxy.getDefinitionAtPosition = (
+    filename: string,
+    cursorPosition: number
+  ) => {
+    const originalDefinitions = info.languageService.getDefinitionAtPosition(
+      filename,
+      cursorPosition
+    );
+
+    const definitions = guard('getDefinitionAtPosition', undefined, () =>
+      getGraphQLDefinitionAtPosition(
+        filename,
+        cursorPosition,
+        schema,
+        info,
+        originalDefinitions
+      )
+    );
+
+    return definitions || originalDefinitions;
+  };
+
+  proxy.getDefinitionAndBoundSpan = (
+    filename: string,
+    cursorPosition: number
+  ) => {
+    const original = info.languageService.getDefinitionAndBoundSpan(
+      filename,
+      cursorPosition
+    );
+
+    const definition = guard('getDefinitionAndBoundSpan', undefined, () =>
+      getGraphQLDefinitionAndBoundSpan(
+        filename,
+        cursorPosition,
+        schema,
+        info,
+        original
+      )
+    );
+
+    return definition || original;
   };
 
   proxy.getQuickInfoAtPosition = (

--- a/packages/graphqlsp/src/quickInfo.ts
+++ b/packages/graphqlsp/src/quickInfo.ts
@@ -14,7 +14,7 @@ import * as checks from './ast/checks';
 import { resolveTemplate } from './ast/resolve';
 import { getToken } from './ast/token';
 import { Cursor } from './ast/cursor';
-import { SchemaRef } from './graphql/getSchema';
+import { SchemaRef, getSchemaForName } from './graphql/getSchema';
 
 export function getGraphQLQuickInfo(
   filename: string,
@@ -40,10 +40,7 @@ export function getGraphQLQuickInfo(
     const typeChecker = info.languageService.getProgram()?.getTypeChecker();
     const schemaName = getSchemaName(node, typeChecker);
 
-    schemaToUse =
-      schemaName && schema.multi[schemaName]
-        ? schema.multi[schemaName]?.schema
-        : schema.current?.schema;
+    schemaToUse = getSchemaForName(schema, schemaName);
 
     const foundToken = getToken(node.arguments[0], cursorPosition);
     if (!schemaToUse || !foundToken) return undefined;

--- a/test/e2e/definition.test.ts
+++ b/test/e2e/definition.test.ts
@@ -22,6 +22,12 @@ const positionAt = (text: string, index: number) => {
   return { line, offset: index - lastNewline };
 };
 
+const indexOf = (text: string, search: string) => {
+  const index = text.indexOf(search);
+  if (index === -1) throw new Error(`Could not find "${search}" in fixture`);
+  return index;
+};
+
 const requestDefinition = async (
   server: TSServer,
   position: { line: number; offset: number }
@@ -105,8 +111,10 @@ describe('go-to-definition', () => {
   it('remaps gql.tada turbo-cache result fields to the source GraphQL document', async () => {
     const position = positionAt(
       fixture,
-      fixture.indexOf('data.pokemon') + 'data.'.length
+      indexOf(fixture, 'data.pokemon') + 'data.'.length
     );
+    const targetFieldIndex =
+      indexOf(fixture, '    pokemon(id: $id)') + '    '.length;
 
     const definition = await waitForDefinition(
       server,
@@ -115,12 +123,15 @@ describe('go-to-definition', () => {
     );
 
     expect(path.normalize(definition.file)).toBe(outfile);
-    expect(definition.start).toEqual({ line: 5, offset: 5 });
+    expect(definition.start).toEqual(positionAt(fixture, targetFieldIndex));
+    expect(definition.end).toEqual(
+      positionAt(fixture, targetFieldIndex + 'pokemon'.length)
+    );
   }, 30000);
 
   it('maps GraphQL document fields to their schema definitions', async () => {
     const schemaFile = path.join(projectPath, 'schema.graphql');
-    const position = positionAt(fixture, fixture.indexOf('      name') + 6);
+    const position = positionAt(fixture, indexOf(fixture, '      name') + 6);
 
     const definition = await waitForDefinition(
       server,

--- a/test/e2e/definition.test.ts
+++ b/test/e2e/definition.test.ts
@@ -1,0 +1,134 @@
+import { expect, afterAll, beforeAll, it, describe } from 'vitest';
+import { TSServer } from './server';
+import path from 'node:path';
+import fs from 'node:fs';
+import url from 'node:url';
+import ts from 'typescript/lib/tsserverlibrary';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const projectPath = path.resolve(__dirname, 'fixture-project-tada');
+const outfile = path.join(projectPath, 'definition.ts');
+const fixture = fs.readFileSync(
+  path.join(projectPath, 'fixtures/definition.ts'),
+  'utf-8'
+);
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+const positionAt = (text: string, index: number) => {
+  const before = text.slice(0, index);
+  const line = before.split('\n').length;
+  const lastNewline = before.lastIndexOf('\n');
+  return { line, offset: index - lastNewline };
+};
+
+const requestDefinition = async (
+  server: TSServer,
+  position: { line: number; offset: number }
+) => {
+  server.send({
+    type: 'request',
+    command: 'definition',
+    arguments: {
+      file: outfile,
+      line: position.line,
+      offset: position.offset,
+    },
+  });
+
+  await server.waitForResponse(
+    response =>
+      response.type === 'response' && response.command === 'definition'
+  );
+
+  return server.responses
+    .slice()
+    .reverse()
+    .find(
+      response =>
+        response.type === 'response' && response.command === 'definition'
+    ) as ts.server.protocol.Response;
+};
+
+const waitForDefinition = async (
+  server: TSServer,
+  position: { line: number; offset: number },
+  predicate: (definition: any) => boolean
+) => {
+  let lastResponse: ts.server.protocol.Response | undefined;
+  for (let attempt = 0; attempt < 20; attempt++) {
+    lastResponse = await requestDefinition(server, position);
+    const definitions = (lastResponse.body || []) as any[];
+    const definition = definitions.find(predicate);
+    if (definition) return definition;
+    await sleep(250);
+  }
+
+  throw new Error(
+    `Expected definition was not found. Last response: ${JSON.stringify(
+      lastResponse?.body,
+      null,
+      2
+    )}`
+  );
+};
+
+describe('go-to-definition', () => {
+  let server: TSServer;
+
+  beforeAll(async () => {
+    server = new TSServer(projectPath, { debugLog: false });
+
+    server.sendCommand('open', {
+      file: outfile,
+      fileContent: '// empty',
+      scriptKindName: 'TS',
+    } satisfies ts.server.protocol.OpenRequestArgs);
+
+    server.sendCommand('updateOpen', {
+      openFiles: [{ file: outfile, fileContent: fixture }],
+    } satisfies ts.server.protocol.UpdateOpenRequestArgs);
+
+    server.sendCommand('saveto', {
+      file: outfile,
+      tmpfile: outfile,
+    } satisfies ts.server.protocol.SavetoRequestArgs);
+  });
+
+  afterAll(() => {
+    try {
+      fs.unlinkSync(outfile);
+    } catch {}
+    server.close();
+  });
+
+  it('remaps gql.tada turbo-cache result fields to the source GraphQL document', async () => {
+    const position = positionAt(
+      fixture,
+      fixture.indexOf('data.pokemon') + 'data.'.length
+    );
+
+    const definition = await waitForDefinition(
+      server,
+      position,
+      definition => path.normalize(definition.file) === outfile
+    );
+
+    expect(path.normalize(definition.file)).toBe(outfile);
+    expect(definition.start).toEqual({ line: 5, offset: 5 });
+  }, 30000);
+
+  it('maps GraphQL document fields to their schema definitions', async () => {
+    const schemaFile = path.join(projectPath, 'schema.graphql');
+    const position = positionAt(fixture, fixture.indexOf('      name') + 6);
+
+    const definition = await waitForDefinition(
+      server,
+      position,
+      definition => path.normalize(definition.file) === schemaFile
+    );
+
+    expect(path.normalize(definition.file)).toBe(schemaFile);
+    expect(definition.start).toEqual({ line: 48, offset: 3 });
+  }, 30000);
+});

--- a/test/e2e/fixture-project-tada/fixtures/definition.ts
+++ b/test/e2e/fixture-project-tada/fixtures/definition.ts
@@ -1,0 +1,18 @@
+import { graphql, ResultOf } from './graphql';
+
+const PokemonQuery = graphql(`
+  query DefinitionQuery($id: ID!) {
+    pokemon(id: $id) {
+      id
+      name
+      weight {
+        minimum
+        maximum
+      }
+    }
+  }
+`);
+
+declare const data: ResultOf<typeof PokemonQuery>;
+
+data.pokemon?.name;

--- a/test/e2e/fixture-project-tada/graphql-cache.d.ts
+++ b/test/e2e/fixture-project-tada/graphql-cache.d.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+/* prettier-ignore */
+import type { TadaDocumentNode } from 'gql.tada';
+
+declare module 'gql.tada' {
+  interface setupCache {
+    '\n  query DefinitionQuery($id: ID!) {\n    pokemon(id: $id) {\n      id\n      name\n      weight {\n        minimum\n        maximum\n      }\n    }\n  }\n': TadaDocumentNode<
+      {
+        pokemon: {
+          id: string;
+          name: string;
+          weight: {
+            minimum: string;
+            maximum: string;
+          };
+        } | null;
+      },
+      { id: string },
+      void
+    >;
+  }
+}

--- a/test/e2e/fixture-project-tada/tsconfig.json
+++ b/test/e2e/fixture-project-tada/tsconfig.json
@@ -4,7 +4,8 @@
       {
         "name": "@0no-co/graphqlsp",
         "schema": "./schema.graphql",
-        "tadaOutputLocation": "./introspection.d.ts"
+        "tadaOutputLocation": "./introspection.d.ts",
+        "tadaTurboLocation": "./graphql-cache.d.ts"
       }
     ],
     "target": "es2016",


### PR DESCRIPTION
## Summary
- add GraphQLSP definition handlers for gql.tada result fields, remapping turbo-cache property definitions back to the source GraphQL document instead of the generated cache
- add GraphQL document field definition support that jumps to the corresponding SDL field in schema.graphql
- track schema and gql.tada turbo cache file locations from plugin config and cover the behavior with an e2e fixture